### PR TITLE
Add electron-redux

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,11 +1,14 @@
 import React from 'react';
 import { render } from 'react-dom';
 import { AppContainer } from 'react-hot-loader';
+import { getInitialStateRenderer } from 'electron-redux';
 import Root from './containers/Root';
-import { configureStore, history } from './store/configureStore';
+import { configureStore } from './store/configureStore';
+import history from './store/history';
 import './app.global.css';
 
-const store = configureStore();
+const initialState = getInitialStateRenderer();
+const store = configureStore(initialState, 'renderer');
 
 render(
   <AppContainer>

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -15,7 +15,6 @@ import MenuBuilder from './menu';
 import { configureStore } from './store/configureStore';
 
 const store = configureStore(undefined, 'main');
-console.log(store);
 
 let mainWindow = null;
 
@@ -86,6 +85,6 @@ app.on('ready', async () => {
     mainWindow = null;
   });
 
-  const menuBuilder = new MenuBuilder(mainWindow);
+  const menuBuilder = new MenuBuilder(mainWindow, store);
   menuBuilder.buildMenu();
 });

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -12,6 +12,10 @@
  */
 import { app, BrowserWindow } from 'electron';
 import MenuBuilder from './menu';
+import { configureStore } from './store/configureStore';
+
+const store = configureStore(undefined, 'main');
+console.log(store);
 
 let mainWindow = null;
 

--- a/app/menu.js
+++ b/app/menu.js
@@ -16,9 +16,10 @@ export default class MenuBuilder {
       this.setupDevelopmentEnvironment();
     }
 
-    const template = process.platform === 'darwin'
-      ? this.buildDarwinTemplate()
-      : this.buildDefaultTemplate();
+    const template =
+      process.platform === 'darwin'
+        ? this.buildDarwinTemplate()
+        : this.buildDefaultTemplate();
 
     const menu = Menu.buildFromTemplate(template);
     Menu.setApplicationMenu(menu);
@@ -141,6 +142,23 @@ export default class MenuBuilder {
         { label: 'Bring All to Front', selector: 'arrangeInFront:' }
       ]
     };
+    const subMenuCounter = {
+      label: 'Counter',
+      submenu: [
+        {
+          label: 'Increase'
+        },
+        {
+          label: 'Decrease'
+        },
+        {
+          label: 'Odd'
+        },
+        {
+          label: 'Async'
+        }
+      ]
+    };
     const subMenuHelp = {
       label: 'Help',
       submenu: [
@@ -176,7 +194,14 @@ export default class MenuBuilder {
     const subMenuView =
       process.env.NODE_ENV === 'development' ? subMenuViewDev : subMenuViewProd;
 
-    return [subMenuAbout, subMenuEdit, subMenuView, subMenuWindow, subMenuHelp];
+    return [
+      subMenuAbout,
+      subMenuEdit,
+      subMenuView,
+      subMenuWindow,
+      subMenuCounter,
+      subMenuHelp
+    ];
   }
 
   buildDefaultTemplate() {

--- a/app/menu.js
+++ b/app/menu.js
@@ -1,11 +1,18 @@
 // @flow
 import { app, Menu, shell, BrowserWindow } from 'electron';
+import {
+  increment,
+  decrement,
+  incrementIfOdd,
+  incrementAsync
+} from './actions/counter';
 
 export default class MenuBuilder {
   mainWindow: BrowserWindow;
 
-  constructor(mainWindow: BrowserWindow) {
+  constructor(mainWindow: BrowserWindow, store) {
     this.mainWindow = mainWindow;
+    this.store = store;
   }
 
   buildMenu() {
@@ -146,16 +153,28 @@ export default class MenuBuilder {
       label: 'Counter',
       submenu: [
         {
-          label: 'Increase'
+          label: 'Increment',
+          click: () => {
+            this.store.dispatch(increment());
+          }
         },
         {
-          label: 'Decrease'
+          label: 'Decrement',
+          click: () => {
+            this.store.dispatch(decrement());
+          }
         },
         {
-          label: 'Odd'
+          label: 'Odd',
+          click: () => {
+            this.store.dispatch(incrementIfOdd());
+          }
         },
         {
-          label: 'Async'
+          label: 'Async',
+          click: () => {
+            this.store.dispatch(incrementAsync());
+          }
         }
       ]
     };

--- a/app/store/configureStore.dev.js
+++ b/app/store/configureStore.dev.js
@@ -1,17 +1,22 @@
 import { createStore, applyMiddleware, compose } from 'redux';
 import thunk from 'redux-thunk';
-import { createHashHistory } from 'history';
+import { hashHistory } from 'react-router';
 import { routerMiddleware, routerActions } from 'react-router-redux';
 import { createLogger } from 'redux-logger';
+import {
+  forwardToMain,
+  forwardToRenderer,
+  triggerAlias,
+  replayActionMain,
+  replayActionRenderer
+} from 'electron-redux';
 import rootReducer from '../reducers';
 import * as counterActions from '../actions/counter';
 import type { counterStateType } from '../reducers/counter';
 
-const history = createHashHistory();
-
-const configureStore = (initialState?: counterStateType) => {
+const configureStore = (initialState?: counterStateType, scope = 'main') => {
   // Redux Configuration
-  const middleware = [];
+  let middleware = [];
   const enhancers = [];
 
   // Thunk Middleware
@@ -29,8 +34,15 @@ const configureStore = (initialState?: counterStateType) => {
   }
 
   // Router Middleware
-  const router = routerMiddleware(history);
-  middleware.push(router);
+
+  if (scope === 'renderer') {
+    const router = routerMiddleware(hashHistory);
+    middleware = [forwardToMain, router, ...middleware];
+  }
+
+  if (scope === 'main') {
+    middleware = [triggerAlias, ...middleware, forwardToRenderer];
+  }
 
   // Redux DevTools Configuration
   const actionCreators = {
@@ -39,12 +51,13 @@ const configureStore = (initialState?: counterStateType) => {
   };
   // If Redux DevTools Extension is installed use it, otherwise use Redux compose
   /* eslint-disable no-underscore-dangle */
-  const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
-    ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
-        // Options: http://zalmoxisus.github.io/redux-devtools-extension/API/Arguments.html
-        actionCreators
-      })
-    : compose;
+  const composeEnhancers =
+    scope === 'renderer' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__
+      ? window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__({
+          // Options: http://zalmoxisus.github.io/redux-devtools-extension/API/Arguments.html
+          actionCreators
+        })
+      : compose;
   /* eslint-enable no-underscore-dangle */
 
   // Apply Middleware & Compose Enhancers
@@ -61,7 +74,13 @@ const configureStore = (initialState?: counterStateType) => {
     );
   }
 
+  if (scope === 'main') {
+    replayActionMain(store);
+  } else {
+    replayActionRenderer(store);
+  }
+
   return store;
 };
 
-export default { configureStore, history };
+export default { configureStore };

--- a/app/store/configureStore.prod.js
+++ b/app/store/configureStore.prod.js
@@ -1,17 +1,41 @@
 // @flow
 import { createStore, applyMiddleware } from 'redux';
 import thunk from 'redux-thunk';
-import { createHashHistory } from 'history';
+import { hashHistory } from 'react-router';
 import { routerMiddleware } from 'react-router-redux';
+import {
+  forwardToMain,
+  forwardToRenderer,
+  triggerAlias,
+  replayActionMain,
+  replayActionRenderer
+} from 'electron-redux';
 import rootReducer from '../reducers';
 import type { counterStateType } from '../reducers/counter';
 
-const history = createHashHistory();
-const router = routerMiddleware(history);
-const enhancer = applyMiddleware(thunk, router);
+const configureStore = (initialState?: counterStateType, scope = 'main') => {
+  let middleware = [thunk];
 
-function configureStore(initialState?: counterStateType) {
-  return createStore(rootReducer, initialState, enhancer);
-}
+  if (scope === 'renderer') {
+    const router = routerMiddleware(hashHistory);
+    middleware = [forwardToMain, router, ...middleware];
+  }
 
-export default { configureStore, history };
+  if (scope === 'main') {
+    middleware = [triggerAlias, ...middleware, forwardToRenderer];
+  }
+
+  const enhancer = applyMiddleware(...middleware);
+
+  const store = createStore(rootReducer, initialState, enhancer);
+
+  if (scope === 'main') {
+    replayActionMain(store);
+  } else {
+    replayActionRenderer(store);
+  }
+
+  return store;
+};
+
+export default { configureStore };

--- a/app/store/history.js
+++ b/app/store/history.js
@@ -1,0 +1,5 @@
+import { createHashHistory } from 'history';
+
+const history = createHashHistory();
+
+export default history;

--- a/package.json
+++ b/package.json
@@ -202,6 +202,7 @@
   "dependencies": {
     "devtron": "^1.4.0",
     "electron-debug": "^1.5.0",
+    "electron-redux": "^1.3.1",
     "font-awesome": "^4.7.0",
     "history": "^4.7.2",
     "react": "^16.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3540,6 +3540,14 @@ electron-rebuild@^1.7.3:
     spawn-rx "^2.0.10"
     yargs "^7.0.2"
 
+electron-redux@^1.3.1:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/electron-redux/-/electron-redux-1.3.1.tgz#650a76cdeb12358f57b5c7db744224d08999ae08"
+  dependencies:
+    debug "^2.3.3"
+    flux-standard-action "^1.0.0"
+    redux "^3.4.0"
+
 electron-to-chromium@^1.2.7, electron-to-chromium@^1.3.30, electron-to-chromium@^1.3.47:
   version "1.3.48"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.48.tgz#d3b0d8593814044e092ece2108fc3ac9aea4b900"
@@ -4443,6 +4451,12 @@ flush-write-stream@^1.0.0:
   dependencies:
     inherits "^2.0.1"
     readable-stream "^2.0.4"
+
+flux-standard-action@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/flux-standard-action/-/flux-standard-action-1.2.0.tgz#d2d41612dde4cebddd11a76cfead8e84fc69ebdc"
+  dependencies:
+    lodash "^4.0.0"
 
 follow-redirects@^1.0.0:
   version "1.5.0"
@@ -5826,6 +5840,9 @@ isobject@^3.0.0, isobject@^3.0.1:
 isomorphic-fetch@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
+  dependencies:
+    node-fetch "^1.0.1"
+    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -6741,7 +6758,7 @@ locate-path@^2.0.0:
     p-locate "^2.0.0"
     path-exists "^3.0.0"
 
-lodash-es@^4.17.5:
+lodash-es@^4.17.5, lodash-es@^4.2.1:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.10.tgz#62cd7104cdf5dd87f235a837f0ede0e8e5117e05"
 
@@ -6785,7 +6802,7 @@ lodash.uniq@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
 
-lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.8.0, lodash@~4.17.4:
+lodash@^4.0.0, lodash@^4.1.0, lodash@^4.13.1, lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.2, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.5.1, lodash@^4.8.0, lodash@~4.17.4:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
@@ -9009,6 +9026,15 @@ redux-thunk@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/redux-thunk/-/redux-thunk-2.2.0.tgz#e615a16e16b47a19a515766133d1e3e99b7852e5"
 
+redux@^3.4.0:
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/redux/-/redux-3.7.2.tgz#06b73123215901d25d065be342eb026bc1c8537b"
+  dependencies:
+    lodash "^4.2.1"
+    lodash-es "^4.2.1"
+    loose-envify "^1.1.0"
+    symbol-observable "^1.0.3"
+
 redux@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/redux/-/redux-4.0.0.tgz#aa698a92b729315d22b34a0553d7e6533555cc03"
@@ -10375,7 +10401,7 @@ symbol-observable@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.1.tgz#8340fc4702c3122df5d22288f88283f513d3fdd4"
 
-symbol-observable@^1.1.0, symbol-observable@^1.2.0:
+symbol-observable@^1.0.3, symbol-observable@^1.1.0, symbol-observable@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 


### PR DESCRIPTION
Due to how electron works, redux is currently only available in the renderer process, which means we can't dispatch redux actions from the main process. For example, we might want to use menu items to dispatch events to our application.

This has been a long-standing issue with this boilerplate:
https://github.com/chentsulin/electron-react-boilerplate/issues/108
https://github.com/chentsulin/electron-react-boilerplate/issues/118
https://github.com/chentsulin/electron-react-boilerplate/issues/968

[electron-redux](https://github.com/hardchor/electron-redux) offers a solution to this problem: run redux in the main process and use IPC to proxy all renderer processes back to the main process.

This PR integrates electron-redux with electron-react-boilerplate and as a demo, allows the counter to be controlled by menu items

![image](https://user-images.githubusercontent.com/792845/42061871-7282c528-7ae0-11e8-9402-4d4167c7593a.png)

I used [timesheets](https://github.com/hardchor/timesheets) as a guide for the implementation, though I wasn't 100% sure on the use of history and initialState. So if anyone has recommendations there, that would be helpful!
