### PR TITLE
Runtime optimizations

### DIFF
--- a/internals/scripts/CheckNativeDep.js
+++ b/internals/scripts/CheckNativeDep.js
@@ -7,7 +7,6 @@ import { dependencies } from '../../package';
 (() => {
   if (!dependencies) return;
 
-  const dependenciesKeys = Object.keys(dependencies);
   const nativeDeps = fs
     .readdirSync('node_modules')
     .filter(folder => fs.existsSync(`node_modules/${folder}/binding.gyp`));
@@ -20,8 +19,8 @@ import { dependencies } from '../../package';
       execSync(`npm ls ${nativeDeps.join(' ')} --json`).toString()
     );
     const rootDependencies = Object.keys(dependenciesObject);
-    const filteredRootDependencies = rootDependencies.filter(rootDependency =>
-      dependenciesKeys.includes(rootDependency)
+    const filteredRootDependencies = rootDependencies.filter(
+      rootDependency => dependencies[rootDependency]
     );
 
     if (filteredRootDependencies.length > 0) {

--- a/internals/scripts/CheckNativeDep.js
+++ b/internals/scripts/CheckNativeDep.js
@@ -16,7 +16,7 @@ import { dependencies } from '../../package';
     // because of a devDependency then that is okay. Warn when it is installed
     // because of a dependency
     const { dependencies: dependenciesObject } = JSON.parse(
-      execSync(`npm ls ${nativeDeps.join(' ')} --json`).toString()
+      execSync(`npm ls ${nativeDeps.join(' ')} --depth 0 --json`).toString()
     );
     const rootDependencies = Object.keys(dependenciesObject);
     const filteredRootDependencies = rootDependencies.filter(


### PR DESCRIPTION
Using `dependencyKeys = Object.keys(dependencies)`then later using `dependencyKeys.includes` creates an unnecessary linear runtime. Simply using `dependencies` as a map is enough. `dependencyKeys` is not used for anything else so it can thus be removed.

We also don't need the whole package tree when running `npm ls` since we only care about the root dependencies -- so we can just use `--depth 0` to grab only those root dependencies.