### PR TITLE
Fix package.json extension missing in webpack config

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -32,11 +32,6 @@
     "flowtype/use-flow-type": "error",
     "flowtype/valid-syntax": "error",
     "generator-star-spacing": "off",
-    "import/extensions": [
-      "error",
-      "ignorePackages",
-      { "js": "never", "jsx": "never", "json": "never" }
-    ],
     "import/no-unresolved": "error",
     "import/no-extraneous-dependencies": "off",
     "jsx-a11y/anchor-is-valid": "off",

--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -19,7 +19,7 @@ function filterDepWithoutEntryPoints(dep: string): boolean {
       return false;
     }
     const pgkString = fs
-      .readFileSync(require.resolve(`${dep}/package`))
+      .readFileSync(require.resolve(`${dep}/package.json`))
       .toString();
     const pkg = JSON.parse(pgkString);
     const fields = ['main', 'module', 'jsnext:main', 'browser'];

--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -5,8 +5,8 @@
 import path from 'path';
 import webpack from 'webpack';
 import fs from 'fs';
-import { dependencies as externals } from '../app/package';
-import { dependencies as possibleExternals } from '../package';
+import { dependencies as externals } from '../app/package.json';
+import { dependencies as possibleExternals } from '../package.json';
 
 // Find all the dependencies without a `main` property and add them as webpack externals
 function filterDepWithoutEntryPoints(dep: string): boolean {

--- a/configs/webpack.config.renderer.dev.dll.js
+++ b/configs/webpack.config.renderer.dev.dll.js
@@ -8,7 +8,7 @@ import webpack from 'webpack';
 import path from 'path';
 import merge from 'webpack-merge';
 import baseConfig from './webpack.config.base';
-import { dependencies } from '../package';
+import { dependencies } from '../package.json';
 import CheckNodeEnv from '../internals/scripts/CheckNodeEnv';
 
 CheckNodeEnv('development');

--- a/internals/scripts/CheckNativeDep.js
+++ b/internals/scripts/CheckNativeDep.js
@@ -2,7 +2,7 @@
 import fs from 'fs';
 import chalk from 'chalk';
 import { execSync } from 'child_process';
-import { dependencies } from '../../package';
+import { dependencies } from '../../package.json';
 
 (() => {
   if (!dependencies) return;

--- a/internals/scripts/ElectronRebuild.js
+++ b/internals/scripts/ElectronRebuild.js
@@ -2,7 +2,7 @@
 import path from 'path';
 import { execSync } from 'child_process';
 import fs from 'fs';
-import { dependencies } from '../../app/package';
+import { dependencies } from '../../app/package.json';
 
 const nodeModulesPath = path.join(__dirname, '..', '..', 'app', 'node_modules');
 


### PR DESCRIPTION
some packages have both `package.js` and `package.json` which make json parse throwing error.

like: https://unpkg.com/moment@2.22.2/package.js and https://unpkg.com/moment@2.22.2/package.json

 