### PR TITLE
Update old url

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,7 @@
 
 - [] Using yarn
 - [] Using an up-to-date master branch
-- [] Using latest version of devtools. See [wiki for howto update](https://github.com/chentsulin/electron-react-boilerplate/wiki/DevTools)
+- [] Using latest version of devtools. See [wiki for howto update](https://github.com/electron-react-boilerplate/electron-react-boilerplate/wiki/DevTools)
 - [] Link to stacktrace in a Gist (for bugs)
 - [] For issue in production release, devtools output of `DEBUG_PROD=true yarn build && yarn start`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,7 @@
 
 #### Breaking
 
-- Changed node dev `__dirname` and `__filename` to node built in fn's (https://github.com/chentsulin/electron-react-boilerplate/pull/1035)
+- Changed node dev `__dirname` and `__filename` to node built in fn's (https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/1035)
 - Renamed `app/bundle.js` to `app/renderer.prod.js` for consistency
 - Renamed `dll/vendor.js` to `dll/renderer.dev.dll.js` for consistency
 
@@ -78,15 +78,15 @@ Yay! Another patch release. This release mostly includes refactorings and router
 
 #### Breaking
 
-- **Renamed `./app/main.development.js` => `./app/main.{dev,prod}.js`:** [#963](https://github.com/chentsulin/electron-react-boilerplate/pull/963)
+- **Renamed `./app/main.development.js` => `./app/main.{dev,prod}.js`:** [#963](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/963)
 
 #### Fixes
 
-- **Fixed reloading when not on `/` path:** [#958](https://github.com/chentsulin/electron-react-boilerplate/pull/958) [#949](https://github.com/chentsulin/electron-react-boilerplate/pull/949)
+- **Fixed reloading when not on `/` path:** [#958](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/958) [#949](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/949)
 
 #### Additions
 
-- **Added support for stylefmt:** [#960](https://github.com/chentsulin/electron-react-boilerplate/pull/960)
+- **Added support for stylefmt:** [#960](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/960)
 
 # 0.11.1 (2017.4.23)
 
@@ -100,11 +100,11 @@ DEBUG_PROD=true npm run package
 
 #### Additions
 
-- **Added support for debugging production build:** [#fab245a](https://github.com/chentsulin/electron-react-boilerplate/pull/941/commits/fab245a077d02a09630f74270806c0c534a4ff95)
+- **Added support for debugging production build:** [#fab245a](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/941/commits/fab245a077d02a09630f74270806c0c534a4ff95)
 
 #### Bug Fixes
 
-- **Fixed bug related to importing native dependencies:** [#933](https://github.com/chentsulin/electron-react-boilerplate/pull/933)
+- **Fixed bug related to importing native dependencies:** [#933](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/933)
 
 #### Improvements
 
@@ -120,7 +120,7 @@ Here's the most notable changes since `v0.10.0`. Its been about a year since a r
 - **Refactored webpack config files**
 - **Migrate to two-package.json project structure**
 - **Updated all devDeps to latest semver**
-- **Migrated to Jest:** [#768](https://github.com/chentsulin/electron-react-boilerplate/pull/768)
+- **Migrated to Jest:** [#768](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/768)
 - **Migrated to `react-router@4`**
 - **Migrated to `electron-builder@4`**
 - **Migrated to `webpack@2`**
@@ -129,40 +129,40 @@ Here's the most notable changes since `v0.10.0`. Its been about a year since a r
 
 #### Additions
 
-- **Added support for Yarn:** [#451](https://github.com/chentsulin/electron-react-boilerplate/pull/451)
-- **Added support for Flow:** [#425](https://github.com/chentsulin/electron-react-boilerplate/pull/425)
-- **Added support for stylelint:** [#911](https://github.com/chentsulin/electron-react-boilerplate/pull/911)
-- **Added support for electron-builder:** [#876](https://github.com/chentsulin/electron-react-boilerplate/pull/876)
-- **Added optional support for SASS:** [#880](https://github.com/chentsulin/electron-react-boilerplate/pull/880)
-- **Added support for eslint-plugin-flowtype:** [#911](https://github.com/chentsulin/electron-react-boilerplate/pull/911)
-- **Added support for appveyor:** [#280](https://github.com/chentsulin/electron-react-boilerplate/pull/280)
-- **Added support for webpack dlls:** [#860](https://github.com/chentsulin/electron-react-boilerplate/pull/860)
-- **Route based code splitting:** [#884](https://github.com/chentsulin/electron-react-boilerplate/pull/884)
-- **Added support for Webpack Bundle Analyzer:** [#922](https://github.com/chentsulin/electron-react-boilerplate/pull/922)
+- **Added support for Yarn:** [#451](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/451)
+- **Added support for Flow:** [#425](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/425)
+- **Added support for stylelint:** [#911](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/911)
+- **Added support for electron-builder:** [#876](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/876)
+- **Added optional support for SASS:** [#880](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/880)
+- **Added support for eslint-plugin-flowtype:** [#911](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/911)
+- **Added support for appveyor:** [#280](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/280)
+- **Added support for webpack dlls:** [#860](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/860)
+- **Route based code splitting:** [#884](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/884)
+- **Added support for Webpack Bundle Analyzer:** [#922](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/922)
 
 #### Improvements
 
 - **Parallelize renderer and main build processes when running `npm run build`**
 - **Dynamically generate electron app menu**
-- **Improved vscode integration:** [#856](https://github.com/chentsulin/electron-react-boilerplate/pull/856)
+- **Improved vscode integration:** [#856](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/856)
 
 #### Bug Fixes
 
-- **Fixed hot module replacement race condition bug:** [#917](https://github.com/chentsulin/electron-react-boilerplate/pull/917) [#920](https://github.com/chentsulin/electron-react-boilerplate/pull/920)
+- **Fixed hot module replacement race condition bug:** [#917](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/917) [#920](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/920)
 
 # 0.10.0 (2016.4.18)
 
 #### Improvements
 
-- **Use Babel in main process with Webpack build:** [#201](https://github.com/chentsulin/electron-react-boilerplate/pull/201)
-- **Change targets to built-in support by webpack:** [#197](https://github.com/chentsulin/electron-react-boilerplate/pull/197)
-- **use es2015 syntax for webpack configs:** [#195](https://github.com/chentsulin/electron-react-boilerplate/pull/195)
-- **Open application when webcontent is loaded:** [#192](https://github.com/chentsulin/electron-react-boilerplate/pull/192)
+- **Use Babel in main process with Webpack build:** [#201](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/201)
+- **Change targets to built-in support by webpack:** [#197](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/197)
+- **use es2015 syntax for webpack configs:** [#195](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/195)
+- **Open application when webcontent is loaded:** [#192](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/192)
 - **Upgraded dependencies**
 
 #### Bug fixed
 
-- **Fix `npm list electron-prebuilt` in package.js:** [#188](https://github.com/chentsulin/electron-react-boilerplate/pull/188)
+- **Fix `npm list electron-prebuilt` in package.js:** [#188](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/188)
 
 # 0.9.0 (2016.3.23)
 
@@ -171,20 +171,20 @@ Here's the most notable changes since `v0.10.0`. Its been about a year since a r
 - **Added [redux-logger](https://github.com/fcomb/redux-logger)**
 - **Upgraded [react-router-redux](https://github.com/reactjs/react-router-redux) to v4**
 - **Upgraded dependencies**
-- **Added `npm run dev` command:** [#162](https://github.com/chentsulin/electron-react-boilerplate/pull/162)
+- **Added `npm run dev` command:** [#162](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/162)
 - **electron to v0.37.2**
 
 #### Breaking Changes
 
-- **css module as default:** [#154](https://github.com/chentsulin/electron-react-boilerplate/pull/154).
-- **set default NODE_ENV to production:** [#140](https://github.com/chentsulin/electron-react-boilerplate/issues/140)
+- **css module as default:** [#154](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/154).
+- **set default NODE_ENV to production:** [#140](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/140)
 
 # 0.8.0 (2016.2.17)
 
 #### Bug fixed
 
 - **Fix lint errors**
-- **Fix Webpack publicPath for production builds**: [#119](https://github.com/chentsulin/electron-react-boilerplate/issues/119).
+- **Fix Webpack publicPath for production builds**: [#119](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/119).
 - **package script now chooses correct OS icon extension**
 
 #### Improvements
@@ -192,15 +192,15 @@ Here's the most notable changes since `v0.10.0`. Its been about a year since a r
 - **babel 6**
 - **Upgrade Dependencies**
 - **Enable CSS source maps**
-- **Add json-loader**: [#128](https://github.com/chentsulin/electron-react-boilerplate/issues/128).
+- **Add json-loader**: [#128](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/128).
 - **react-router 2.0 and react-router-redux 3.0**
 
 # 0.7.1 (2015.12.27)
 
 #### Bug fixed
 
-- **Fixed npm script on windows 10:** [#103](https://github.com/chentsulin/electron-react-boilerplate/issues/103).
-- **history and react-router version bump**: [#109](https://github.com/chentsulin/electron-react-boilerplate/issues/109), [#110](https://github.com/chentsulin/electron-react-boilerplate/pull/110).
+- **Fixed npm script on windows 10:** [#103](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/103).
+- **history and react-router version bump**: [#109](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/109), [#110](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/110).
 
 #### Improvements
 
@@ -210,11 +210,11 @@ Here's the most notable changes since `v0.10.0`. Its been about a year since a r
 
 #### Bug fixed
 
-- **Fixed process.env.NODE_ENV variable in webpack:** [#74](https://github.com/chentsulin/electron-react-boilerplate/pull/74).
-- **add missing object-assign**: [#76](https://github.com/chentsulin/electron-react-boilerplate/pull/76).
-- **packaging in npm@3:** [#77](https://github.com/chentsulin/electron-react-boilerplate/pull/77).
-- **compatibility in windows:** [#100](https://github.com/chentsulin/electron-react-boilerplate/pull/100).
-- **disable chrome debugger in production env:** [#102](https://github.com/chentsulin/electron-react-boilerplate/pull/102).
+- **Fixed process.env.NODE_ENV variable in webpack:** [#74](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/74).
+- **add missing object-assign**: [#76](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/76).
+- **packaging in npm@3:** [#77](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/77).
+- **compatibility in windows:** [#100](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/100).
+- **disable chrome debugger in production env:** [#102](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/102).
 
 #### Improvements
 
@@ -245,13 +245,13 @@ Here's the most notable changes since `v0.10.0`. Its been about a year since a r
 
 #### Improvements
 
-- **Initialize ExtractTextPlugin once:** [#64](https://github.com/chentsulin/electron-react-boilerplate/issues/64).
+- **Initialize ExtractTextPlugin once:** [#64](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/64).
 
 # 0.6.2 (2015.10.18)
 
 #### Bug fixed
 
-- **Babel plugins production env not be set properly:** [#57](https://github.com/chentsulin/electron-react-boilerplate/issues/57).
+- **Babel plugins production env not be set properly:** [#57](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/57).
 
 # 0.6.1 (2015.10.17)
 
@@ -269,7 +269,7 @@ Here's the most notable changes since `v0.10.0`. Its been about a year since a r
 
 #### Improvements
 
-- **Run tests with babel-register:** [#29](https://github.com/chentsulin/electron-react-boilerplate/issues/29).
+- **Run tests with babel-register:** [#29](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/29).
 
 # 0.5.1 (2015.10.12)
 
@@ -281,7 +281,7 @@ Here's the most notable changes since `v0.10.0`. Its been about a year since a r
 
 #### Improvements
 
-- **Simplify webpack config** see [#50](https://github.com/chentsulin/electron-react-boilerplate/pull/50).
+- **Simplify webpack config** see [#50](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/50).
 
 #### Breaking Changes
 
@@ -370,7 +370,7 @@ Here's the most notable changes since `v0.10.0`. Its been about a year since a r
 
 #### Bug fixed
 
-- **Eslint:** typo, [#17](https://github.com/chentsulin/electron-react-boilerplate/issues/17) and improve `.eslintrc`
+- **Eslint:** typo, [#17](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/17) and improve `.eslintrc`
 
 # 0.2.3 (2015.6.3)
 
@@ -381,8 +381,8 @@ Here's the most notable changes since `v0.10.0`. Its been about a year since a r
 
 #### Bug fixed
 
-- **Npm Script:** typo, [#6](https://github.com/chentsulin/electron-react-boilerplate/pull/6)
-- **Missing css:** [#7](https://github.com/chentsulin/electron-react-boilerplate/pull/7)
+- **Npm Script:** typo, [#6](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/6)
+- **Missing css:** [#7](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/7)
 
 # 0.2.2 (2015.6.2)
 

--- a/README.md
+++ b/README.md
@@ -56,12 +56,12 @@ A boilerplate for Scalable Cross-Platform Desktop Apps based on  <a href="http:/
 
 ## Install
 
-- **If you have installation or compilation issues with this project, please see [our debugging guide](https://github.com/chentsulin/electron-react-boilerplate/issues/400)**
+- **If you have installation or compilation issues with this project, please see [our debugging guide](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/400)**
 
 First, clone the repo via git:
 
 ```bash
-git clone --depth=1 https://github.com/chentsulin/electron-react-boilerplate.git your-project-name
+git clone --depth=1 https://github.com/electron-react-boilerplate/electron-react-boilerplate.git your-project-name
 ```
 
 And then install dependencies with yarn.
@@ -157,7 +157,7 @@ This boilerplate uses a [two package.json structure](https://github.com/electron
 
 ### Further Readings
 
-See the wiki page, [Module Structure — Two package.json Structure](https://github.com/chentsulin/electron-react-boilerplate/wiki/Module-Structure----Two-package.json-Structure) to understand what is native module, the rationale behind two package.json structure and more.
+See the wiki page, [Module Structure — Two package.json Structure](https://github.com/electron-react-boilerplate/electron-react-boilerplate/wiki/Module-Structure----Two-package.json-Structure) to understand what is native module, the rationale behind two package.json structure and more.
 
 For an example app that uses this boilerplate and packages native dependencies, see [erb-sqlite-example](https://github.com/amilajack/erb-sqlite-example).
 
@@ -190,14 +190,14 @@ This project comes with Flow support out of the box! You can annotate your code 
 
 ## Dispatching redux actions from main process
 
-See [#118](https://github.com/chentsulin/electron-react-boilerplate/issues/118) and [#108](https://github.com/chentsulin/electron-react-boilerplate/issues/108)
+See [#118](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/118) and [#108](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/108)
 
 ## How to keep your project updated with the boilerplate
 
 If your application is a fork from this repo, you can add this repo to another git remote:
 
 ```sh
-git remote add upstream https://github.com/chentsulin/electron-react-boilerplate.git
+git remote add upstream https://github.com/electron-react-boilerplate/electron-react-boilerplate.git
 ```
 
 Then, use git to merge some latest commits:
@@ -288,7 +288,7 @@ MIT © [C. T. Lin](https://github.com/chentsulin)
 
 [npm-image]: https://img.shields.io/npm/v/electron-react-boilerplate.svg?style=flat-square
 [github-tag-image]: https://img.shields.io/github/tag/chentsulin/electron-react-boilerplate.svg
-[github-tag-url]: https://github.com/chentsulin/electron-react-boilerplate/releases/latest
+[github-tag-url]: https://github.com/electron-react-boilerplate/electron-react-boilerplate/releases/latest
 [travis-image]: https://travis-ci.org/chentsulin/electron-react-boilerplate.svg?branch=master
 [travis-url]: https://travis-ci.org/chentsulin/electron-react-boilerplate
 [appveyor-image]: https://ci.appveyor.com/api/projects/status/github/chentsulin/electron-react-boilerplate?svg=true

--- a/internals/scripts/CheckNativeDep.js
+++ b/internals/scripts/CheckNativeDep.js
@@ -50,7 +50,7 @@ ${chalk.whiteBright.bgGreen.bold('cd ./app && yarn add your-package')}
 
 Read more about native dependencies at:
 ${chalk.bold(
-        'https://github.com/chentsulin/electron-react-boilerplate/wiki/Module-Structure----Two-package.json-Structure'
+        'https://github.com/electron-react-boilerplate/electron-react-boilerplate/wiki/Module-Structure----Two-package.json-Structure'
       )}
 
 

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/chentsulin/electron-react-boilerplate.git"
+    "url": "git+https://github.com/electron-react-boilerplate/electron-react-boilerplate.git"
   },
   "author": {
     "name": "C. T. Lin",
@@ -113,7 +113,7 @@
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/chentsulin/electron-react-boilerplate/issues"
+    "url": "https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues"
   },
   "keywords": [
     "electron",
@@ -126,7 +126,7 @@
     "hot",
     "reload"
   ],
-  "homepage": "https://github.com/chentsulin/electron-react-boilerplate#readme",
+  "homepage": "https://github.com/electron-react-boilerplate/electron-react-boilerplate#readme",
   "jest": {
     "testURL": "http://localhost/",
     "moduleNameMapper": {


### PR DESCRIPTION
Fixes: #1846 

We need to change this old URL
`https://github.com/chentsulin/electron-react-boilerplate` by
`https://github.com/electron-react-boilerplate/electron-react-boilerplate`