### PR TITLE
webpack - only include App files for babel

### DIFF
--- a/configs/webpack.config.renderer.dev.js
+++ b/configs/webpack.config.renderer.dev.js
@@ -61,6 +61,7 @@ export default merge.smart(baseConfig, {
     rules: [
       {
         test: /\.jsx?$/,
+        include: path.join(__dirname, 'app'),
         exclude: /node_modules/,
         use: {
           loader: 'babel-loader',


### PR DESCRIPTION
When i link package to app via `yarn link _package_` got error 

> Unknown plugin "react-hot-loader/babel" specified in "base" at 2

Same issue here https://github.com/hubgit/react-prosemirror/issues/7

Fixed by add 
`include: path.join(__dirname, 'src')` 
to webpack.config.renderer.dev.js
And babel-loader from boilerplate stop trying to parse files from linked module.