### PR TITLE
Remove app/node_modules from .gitignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -26,7 +26,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
-app/node_modules
 
 # OSX
 .DS_Store

--- a/.eslintignore
+++ b/.eslintignore
@@ -26,7 +26,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
-app/node_modules
 
 # OSX
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
-app/node_modules
 
 # OSX
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ build/Release
 
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
-node_modules
+/node_modules
 
 # OSX
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,7 @@ build/Release
 
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
-/node_modules
+node_modules
 
 # OSX
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,6 @@ cache:
   yarn: true
   directories:
     - node_modules
-    - app/node_modules
     - $(npm config get prefix)/lib/node_modules
     - flow-typed
     - $HOME/.cache/electron


### PR DESCRIPTION
In previous versions of electron-react-boilerplate, there was a
2-package.json structure where modules were installed in
./node_modules and ./app/node_modules. We've since migrated to a
single package.json system, and there should only be ./node_modules
present. If you notice ./app/node_modules (i.e. when running `git
status`), you can safely delete the director ./app/node_modules. All
dependencies are downloaded in ./node_modules now.

History: https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/1854