### PR TITLE
Fix versions in package.json

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,9 @@ matrix:
     - os: osx
       language: node_js
       node_js:
-        - node
+        # Uncomment line below once node 11 is stable
+        # - node
+        - 10
       env:
         - ELECTRON_CACHE=$HOME/.cache/electron
         - ELECTRON_BUILDER_CACHE=$HOME/.cache/electron-builder
@@ -13,7 +15,9 @@ matrix:
     - os: linux
       language: node_js
       node_js:
-        - node
+        # Uncomment line below once node 11 is stable
+        # - node
+        - 10
       addons:
         apt:
           sources:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 matrix:
   allow_failures:
     - os: windows
+    - node_js: node
   include:
     - os: osx
       language: node_js
       node_js:
-        # Uncomment line below once node 11 is stable
-        # - node
+        - node
         - 10
       env:
         - ELECTRON_CACHE=$HOME/.cache/electron
@@ -15,8 +15,7 @@ matrix:
     - os: linux
       language: node_js
       node_js:
-        # Uncomment line below once node 11 is stable
-        # - node
+        - node
         - 10
       addons:
         apt:
@@ -56,7 +55,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export CXX="g++-8"; fi
 
 install:
-  - yarn
+  - yarn --ignore-engines
   # On Linux, initialize "virtual display". See before_script
   - |
     if [ "$TRAVIS_OS_NAME" == "linux" ]; then

--- a/package.json
+++ b/package.json
@@ -271,8 +271,8 @@
     "redux-thunk": "^2.3.0",
     "source-map-support": "^0.5.6"
   },
-  "devEngines": {
-    "node": ">=7.x",
+  "engines": {
+    "node": ">=10.x <11",
     "npm": ">=4.x",
     "yarn": ">=0.21.3"
   },

--- a/package.json
+++ b/package.json
@@ -273,7 +273,6 @@
   },
   "engines": {
     "node": ">=10.x <11",
-    "npm": ">=4.x",
     "yarn": ">=0.21.3"
   },
   "collective": {

--- a/package.json
+++ b/package.json
@@ -273,7 +273,7 @@
   },
   "engines": {
     "node": ">=10.x <11",
-    "yarn": ">=0.21.3"
+    "yarn": ">=1.x"
   },
   "collective": {
     "url": "https://opencollective.com/electron-react-boilerplate-594"


### PR DESCRIPTION
Project is not currently working with Node 11. [#1957](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/1957#issuecomment-435618180)

Change `devEngines` to `engines` so `yarn` will throw an error if incorrect versions are used.