### PR TITLE
Cache node_modules based on yarn.lock

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ environment:
 
 cache:
   - '%LOCALAPPDATA%/Yarn'
-  - node_modules -> package.json
+  - node_modules -> yarn.lock
   - flow-typed
   - '%USERPROFILE%\.electron'
 


### PR DESCRIPTION
If a dep has been updated in `yarn.lock` but not in `package.json`, the cache should be rebuilt.