### PR TITLE
fix package size bug

### DIFF
--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -4,11 +4,8 @@
 
 import path from 'path';
 import webpack from 'webpack';
-import { dependencies } from '../package.json';
 
 export default {
-  externals: [...Object.keys(dependencies || {})],
-
   module: {
     rules: [
       {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "productName": "ElectronReact",
     "appId": "org.develar.ElectronReact",
     "files": [
+      "!node_modules",
       "app/dist/",
       "app/app.html",
       "app/main.prod.js",


### PR DESCRIPTION
All the dependencies were being treated as externals. Because webpack bundles all our node modules, we do not need to include them in our packaged electron app. `electron-builder` adds all files in `**/*` glob to packaged app so this was why `node_modules` was included. This fix will pose issues for projects that uses native deps because webpack cannot handle native deps yet. With our two `package.json` architecture, we did ship `app/node_modules` which was the only solution. We need to investigate solutions for native deps with this single `package.json` architecture.