### PR TITLE
Changed Devtron package to dev-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -198,6 +198,7 @@
     "cross-spawn": "^6.0.5",
     "css-loader": "^1.0.1",
     "detect-port": "^1.2.3",
+    "devtron": "^1.4.0",
     "electron": "^2.0.6",
     "electron-builder": "^20.28.4",
     "electron-devtools-installer": "^2.2.4",
@@ -256,7 +257,6 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^5.2.0",
-    "devtron": "^1.4.0",
     "electron-debug": "^2.0.0",
     "electron-log": "^2.2.17",
     "electron-updater": "^3.1.6",


### PR DESCRIPTION
Official install guide shows installing as dev-dependency as well.
Also you presumably wouldn't want to ship a nice tool capable of scrutinizing your ipc messsages, amongst other things, with your production app.