### PR TITLE
Remove existing docs and refer to site docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ $ cd your-project-name
 $ yarn
 ```
 
-## Run
+## Starting Development
 
 Start the app in the `dev` environment. This starts the renderer process in [**hot-module-replacement**](https://webpack.js.org/guides/hmr-react/) mode and starts a webpack dev server that sends hot updates to the renderer process:
 
@@ -85,7 +85,7 @@ If you don't need autofocus when your files was changed, then run `dev` with env
 $ START_MINIMIZED=true yarn dev
 ```
 
-## Packaging
+## Packaging for Production
 
 To package apps for the local platform:
 
@@ -93,83 +93,8 @@ To package apps for the local platform:
 $ yarn package
 ```
 
-To package apps for all platforms:
-
-First, refer to the [Multi Platform Build docs](https://www.electron.build/multi-platform-build) for dependencies.
-
-Then,
-
-```bash
-$ yarn package-all
-```
-
-To package apps with options:
-
-```bash
-$ yarn package --[option]
-```
-
-To run End-to-End Test
-
-```bash
-$ yarn build-e2e
-$ yarn test-e2e
-
-# Running e2e tests in a minimized window
-$ START_MINIMIZED=true yarn build-e2e
-$ yarn test-e2e
-```
-
-:bulb: You can debug your production build with devtools by simply setting the `DEBUG_PROD` env variable:
-
-```bash
-DEBUG_PROD=true yarn package
-```
-
-## CSS Modules
-
-This boilerplate is configured to use [css-modules](https://github.com/css-modules/css-modules) out of the box.
-
-All `.css` file extensions will use css-modules unless it has `.global.css`.
-
-If you need global styles, stylesheets with `.global.css` will not go through the
-css-modules loader. e.g. `app.global.css`
-
-If you want to import global css libraries (like `bootstrap`), you can just write the following code in `.global.css`:
-
-```css
-@import '~bootstrap/dist/css/bootstrap.css';
-```
-
-## SASS support
-
-If you want to use Sass in your app, you only need to import `.sass` files instead of `.css` once:
-
-```js
-import './app.global.scss';
-```
-
-## Static Type Checking
-
-This project comes with Flow support out of the box! You can annotate your code with types, [get Flow errors as ESLint errors](https://github.com/amilajack/eslint-plugin-flowtype-errors), and get [type errors during runtime](https://github.com/codemix/flow-runtime) during development. Types are completely optional.
-
-## Dispatching redux actions from main process
-
-See [#118](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/118) and [#108](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/108)
-
-## How to keep your project updated with the boilerplate
-
-If your application is a fork from this repo, you can add this repo to another git remote:
-
-```sh
-git remote add upstream https://github.com/electron-react-boilerplate/electron-react-boilerplate.git
-```
-
-Then, use git to merge some latest commits:
-
-```sh
-git pull upstream master
-```
+## Docs
+See our [complete docs here](https://electron-react-boilerplate.js.org/docs/en/installation)
 
 ## Maintainers
 


### PR DESCRIPTION
I kept all the docs that were only essential to getting started with ERB