### PR TITLE
Update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,12 +39,14 @@ A boilerplate for Scalable Cross-Platform Desktop Apps based on  <a href="http:/
 
 [![Build Status][travis-image]][travis-url]
 [![Appveyor Build Status][appveyor-image]][appveyor-url]
-[![Dependency Status][david_img]][david_site]
-[![DevDependency Status][david_img_dev]][david_site_dev]
+[![Dependency Status][david-image]][david-url]
+[![DevDependency Status][david-dev-image]][david-dev-url]
 [![Github Tag][github-tag-image]][github-tag-url]
+
 [![Join the community on Spectrum](https://withspectrum.github.io/badge/badge.svg)](https://spectrum.chat/electron-react-blpt)
 [![OpenCollective](https://opencollective.com/electron-react-boilerplate/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/electron-react-boilerplate/sponsors/badge.svg)](#sponsors)
+[![Good first issues open][good-first-issue-image]][good-first-issue-url]
 
 </div>
 
@@ -94,6 +96,7 @@ $ yarn package
 ```
 
 ## Docs
+
 See our [complete docs here](https://electron-react-boilerplate.js.org/docs/en/installation)
 
 ## Maintainers
@@ -178,13 +181,15 @@ Become a sponsor and get your logo on our README on Github with a link to your s
 MIT © [Electron React Boilerplate](https://github.com/electron-react-boilerplate)
 
 [npm-image]: https://img.shields.io/npm/v/electron-react-boilerplate.svg?style=flat-square
-[github-tag-image]: https://img.shields.io/github/tag/electron-react-boilerplate/electron-react-boilerplate.svg
+[github-tag-image]: https://img.shields.io/github/tag/electron-react-boilerplate/electron-react-boilerplate.svg?label=version
 [github-tag-url]: https://github.com/electron-react-boilerplate/electron-react-boilerplate/releases/latest
-[travis-image]: https://travis-ci.com/electron-react-boilerplate/electron-react-boilerplate.svg?branch=master
+[travis-image]: https://img.shields.io/travis/com/electron-react-boilerplate/electron-react-boilerplate.svg?logo=travis
 [travis-url]: https://travis-ci.com/electron-react-boilerplate/electron-react-boilerplate
-[appveyor-image]: https://ci.appveyor.com/api/projects/status/github/electron-react-boilerplate/electron-react-boilerplate?svg=true
+[appveyor-image]: https://img.shields.io/appveyor/ci/electron-react-boilerplate/electron-react-boilerplate.svg?logo=appveyor
 [appveyor-url]: https://ci.appveyor.com/project/electron-react-boilerplate/electron-react-boilerplate/branch/master
-[david_img]: https://img.shields.io/david/electron-react-boilerplate/electron-react-boilerplate.svg
-[david_site]: https://david-dm.org/electron-react-boilerplate/electron-react-boilerplate
-[david_img_dev]: https://david-dm.org/electron-react-boilerplate/electron-react-boilerplate/dev-status.svg
-[david_site_dev]: https://david-dm.org/electron-react-boilerplate/electron-react-boilerplate?type=dev
+[david-image]: https://img.shields.io/david/electron-react-boilerplate/electron-react-boilerplate.svg
+[david-url]: https://david-dm.org/electron-react-boilerplate/electron-react-boilerplate
+[david-dev-image]: https://img.shields.io/david/dev/electron-react-boilerplate/electron-react-boilerplate.svg?label=devDependencies
+[david-dev-url]: https://david-dm.org/electron-react-boilerplate/electron-react-boilerplate?type=dev
+[good-first-issue-image]: https://img.shields.io/github/issues/electron-react-boilerplate/electron-react-boilerplate/good%20first%20issue.svg?label=good%20first%20issues
+[good-first-issue-url]: https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues?q=is%3Aopen+is%3Aissue+label%3A"good+first+issue"


### PR DESCRIPTION
- Add badge for number of github issue tickets open (closes #2017) 
- Rename `david_` links to match the schemas of the other links (i.e. `david_img` => `david-image`)
- Make `tag` badge use label `version` instead
- Fetch badges for travis, appveyor, and david_dm from shields.io
  - Include travis logo in travis build badge
- Separate social badges to their own row