### PR TITLE
Add support for mono-repos by specify packages as scoped

### DIFF
--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -1,13 +1,22 @@
 /**
  * Base webpack config used across other specific configs
  */
-
+import fs from 'fs';
 import path from 'path';
 import webpack from 'webpack';
-import { dependencies } from '../package.json';
+import nodeExternals from 'webpack-node-externals';
+import CheckForMonoRepoPackage from '../internals/scripts/CheckForMonoRepoPackage';
 
 export default {
-  externals: [...Object.keys(dependencies || {})],
+  externals: fs.readdirSync(path.join(__dirname, '../..')).map(directory =>
+    nodeExternals({
+      modulesFromFile: {
+        fileName: path.join('..', directory, 'package.json'),
+        include: ['dependencies']
+      },
+      whitelist: CheckForMonoRepoPackage
+    })
+  ),
 
   module: {
     rules: [

--- a/internals/scripts/CheckForMonoRepoPackage.js
+++ b/internals/scripts/CheckForMonoRepoPackage.js
@@ -1,0 +1,8 @@
+const { name } = require('../../package.json');
+
+const scopedPackageRegex = /^(@.+)\//;
+
+const isScopedPackage = scopedPackageRegex.test(name);
+
+module.exports = moduleName =>
+  isScopedPackage && scopedPackageRegex.test(moduleName);

--- a/internals/scripts/RegisterBabelWithOptions.js
+++ b/internals/scripts/RegisterBabelWithOptions.js
@@ -1,0 +1,7 @@
+const CheckForMonoRepoPackage = require('./CheckForMonoRepoPackage');
+
+require('@babel/register')({
+  ignore: [
+    module => !CheckForMonoRepoPackage(module) && /node_modules/.test(module)
+  ]
+});

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "precommit": "lint-staged",
     "prestart": "yarn build",
     "start": "cross-env NODE_ENV=production electron ./app/main.prod.js",
-    "start-main-dev": "cross-env HOT=1 NODE_ENV=development electron -r @babel/register ./app/main.dev.js",
+    "start-main-dev": "cross-env HOT=1 NODE_ENV=development electron -r ./internals/scripts/RegisterBabelWithOptions.js ./app/main.dev.js",
     "start-renderer-dev": "cross-env NODE_ENV=development webpack-dev-server --config configs/webpack.config.renderer.dev.babel.js",
     "test": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 jest",
     "test-all": "yarn lint && yarn flow && yarn build && yarn test && yarn build-e2e && yarn test-e2e",
@@ -252,6 +252,7 @@
     "webpack-cli": "^3.1.2",
     "webpack-dev-server": "^3.1.10",
     "webpack-merge": "^4.1.4",
+    "webpack-node-externals": "^1.7.2",
     "yarn": "^1.12.3"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -11690,6 +11690,11 @@ webpack-merge@^4.1.4:
   dependencies:
     lodash "^4.17.5"
 
+webpack-node-externals@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
+  integrity sha512-ajerHZ+BJKeCLviLUUmnyd5B4RavLF76uv3cs6KNuO8W+HuQaEs0y0L7o40NQxdPy5w0pcv8Ew7yPUAQG0UdCg==
+
 webpack-sources@^1.1.0, webpack-sources@^1.3.0:
   version "1.3.0"
   resolved "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.3.0.tgz#2a28dcb9f1f45fe960d8f1493252b5ee6530fa85"


### PR DESCRIPTION
## Expected Behavior

<!--- If you're describing a bug, tell us what should happen -->
<!--- If you're suggesting a change/improvement, tell us how it should work -->
I would expect to put the boilerplate in a yarn workspace, add another package in the workspace that requires babel compilation, and require that second package in the boilerplate package. Running `yarn dev` or packaging the component should properly build run the package.

## Current Behavior

<!--- If describing a bug, tell us what happens instead of the expected behavior -->
<!--- If suggesting a change/improvement, explain the difference from current behavior -->
Errors occur resolving dependencies from the secondary workspace package.

## Steps to Reproduce (for bugs)

<!--- Provide a link to a live example, or an unambiguous set of steps to -->
<!--- reproduce this bug. Include code to reproduce, if relevant -->

1. Create an empty workspace in the project root:
```json
{
  "private": true,
  "workspaces": ["packages/*"]
}
```

2. Clone the boilerplate into a package:
```
git clone --depth 1 --single-branch --branch master https://github.com/electron-react-boilerplate/electron-react-boilerplate.git packages/electron-app
```

3. Add the new secondary package and initialize yarn:
```
mkdir -p packages/database && cd $_ && yarn init
```

4. Require the secondary package within the boilerplate app and run `yarn install` in the project root

For my example, i tried to make a simple sqlite database package. It simply consists of two files, within `packages/database/models`:

- [index.js](https://gist.github.com/LordZardeck/686b5046b7ccd40e737f05b6492ad96f#file-index-js)
- [tasks.js](https://gist.github.com/LordZardeck/686b5046b7ccd40e737f05b6492ad96f#file-tasks-js)

Including this within `packages/electron-app/containers/App.js` as `import db from '@timing-export/database';` causes the following error in the renderer process:

```
vm.js:74 Uncaught SyntaxError: Unexpected identifier
    at new Script (vm.js:74)
    at createScript (vm.js:246)
    at Object.runInThisContext (vm.js:298)
    at Module._compile (internal/modules/cjs/loader.js:678)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:722)
    at Module.load (internal/modules/cjs/loader.js:620)
    at tryModuleLoad (internal/modules/cjs/loader.js:559)
    at Function.Module._load (internal/modules/cjs/loader.js:551)
    at Module.require (internal/modules/cjs/loader.js:658)
    at require (internal/modules/cjs/helpers.js:20)
```
Now while it doesn't say what identifier is unexpected, I'm pretty sure it's the `import` statement. This all worked 100% when it didn't need babel compiling, and when I converted it to use `import` statements, the first thing that failed was the main process. By adding a config for `@babel/register` to not ignore my packages:

```js
require('@babel/register')({
	ignore: [
		/node_modules\/(?!(@timing-export)\/?).*/
	]
});
```

This instantly fixed my main renderer process. (`@timing-export` is the scope I put my `database` module under). Now my first thought was to try to accomplish the same thing in the webpack configuration.

I tried setting the `exclude` to `/node_modules\/(?!(@timing-export)\/?).*/` as well, but that made no effect. The next thing I tried was to remove my package as an external. That's when things really blew up. I got all kinds of errors regarding packages my `database` package depended on: [log-output](https://gist.github.com/LordZardeck/686b5046b7ccd40e737f05b6492ad96f#file-log-output)

So then after a bit more digging, I realized not only did my other package have to be marked as not external, I also needed each and every dependency for every monorepo package to be marked _as_ external. So that brings me to this PR.

I thought about the most non-intrusive, but simplest to implement way of getting workspaces setup, and I figured using the scoped package syntax would suffice. If any of you think of a better way to implement this, I'm all ears as I'm new to this whole monorepo/yarn workspaces mentality anyway.

My solution consists of setting up each package using a scoped name, such as `@monorepo/electron-app` and `@monorepo/electron-app-dependency`. Using that logic, I scan the folders for `package.json` files and read them in, whitelisting any scoped packages under the same scope as the electron boilerplate.

If I did this all wrong in the first place, please let me know how I should have setup mono-repos with yarn workspaces. I spent _hours_ debugging these issues having absolutely no direction.
