### PR TITLE
Added window re-activation for MacOS

### DIFF
--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -104,6 +104,6 @@ async function createWindow() {
 app.on('ready', createWindow);
 app.on('activate', () => {
   if (mainWindow === null && process.platform === 'darwin') {
-    createNewWindow();
+    createWindow();
   }
 })

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -106,4 +106,4 @@ app.on('activate', () => {
   if (mainWindow === null && process.platform === 'darwin') {
     createWindow();
   }
-})
+});

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -59,7 +59,7 @@ app.on('window-all-closed', () => {
   }
 });
 
-app.on('ready', async () => {
+async function createWindow() {
   if (
     process.env.NODE_ENV === 'development' ||
     process.env.DEBUG_PROD === 'true'
@@ -99,4 +99,11 @@ app.on('ready', async () => {
   // Remove this if your app does not use auto updates
   // eslint-disable-next-line
   new AppUpdater();
-});
+}
+
+app.on('ready', createWindow);
+app.on('activate', () => {
+  if (mainWindow === null && process.platform === 'darwin') {
+    createNewWindow();
+  }
+})


### PR DESCRIPTION
On MacOS, when you close the window using the "x" close button, you cannot re-open the app unless right clicking on the app icon in dock and selecting "Quit" and then start it again. This change re-creates the window when clicking on the dock icon after the window has been soft-closed.