### PR TITLE
add PLAIN_HMR environment variable option

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { render } from 'react-dom';
 import { AppContainer as ReactHotAppContainer } from 'react-hot-loader';
 import Root from './containers/Root';

--- a/app/index.js
+++ b/app/index.js
@@ -1,11 +1,15 @@
 import React from 'react';
 import { render } from 'react-dom';
-import { AppContainer } from 'react-hot-loader';
+import { AppContainer as ReactHotAppContainer } from 'react-hot-loader';
 import Root from './containers/Root';
 import { configureStore, history } from './store/configureStore';
 import './app.global.css';
 
 const store = configureStore();
+
+const AppContainer = process.env.PLAIN_HMR
+  ? React.Fragment
+  : ReactHotAppContainer;
 
 render(
   <AppContainer>

--- a/configs/webpack.config.renderer.dev.babel.js
+++ b/configs/webpack.config.renderer.dev.babel.js
@@ -46,7 +46,7 @@ export default merge.smart(baseConfig, {
   target: 'electron-renderer',
 
   entry: [
-    'react-hot-loader/patch',
+    ...(process.env.PLAIN_HMR ? [] : ['react-hot-loader/patch']),
     `webpack-dev-server/client?http://localhost:${port}/`,
     'webpack/hot/only-dev-server',
     require.resolve('../app/index')


### PR DESCRIPTION
Running `yarn dev` with `PLAIN_HMR=1` (any non-empty string) will disable `react-hot-loader` and rely
solely on existing code that remounts the `Root` component with plain HMR.

This is a quick escape hatch to enable someone to keep working if they encounter an issue like bugs in the code output by `react-hot-loader`'s babel plugin.  Ever since I encountered an issue like that in the past, I decided plain HMR was good enough for me.

fix #2150