### PR TITLE
Adds Electron-Unhandled

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1,9 +1,18 @@
 import React, { Fragment } from 'react';
 import { render } from 'react-dom';
 import { AppContainer as ReactHotAppContainer } from 'react-hot-loader';
+import log from 'electron-log';
 import Root from './containers/Root';
 import { configureStore, history } from './store/configureStore';
 import './app.global.css';
+
+
+const unhandled = require('electron-unhandled');
+
+unhandled({
+  logger: log.error,
+});
+
 
 const store = configureStore();
 

--- a/app/main.dev.js
+++ b/app/main.dev.js
@@ -15,6 +15,12 @@ import { autoUpdater } from 'electron-updater';
 import log from 'electron-log';
 import MenuBuilder from './menu';
 
+const unhandled = require('electron-unhandled');
+
+unhandled({
+  logger: log.error,
+});
+
 export default class AppUpdater {
   constructor() {
     log.transports.file.level = 'info';

--- a/package.json
+++ b/package.json
@@ -261,6 +261,7 @@
     "devtron": "^1.4.0",
     "electron-debug": "^2.1.0",
     "electron-log": "^3.0.4",
+    "electron-unhandled": "^2.2.0",
     "electron-updater": "^4.0.6",
     "history": "^4.9.0",
     "react": "^16.8.6",


### PR DESCRIPTION
This is a simple change so this should just work, but I have not tested it. I just made the edits in-browser.

This should reduce headaches for users of the boilerplate and for maintainers too via a reduction in issues.

In my project I hide the errors in production with `showDialog: false`:

```
unhandled({
    showDialog: false,
    logger: log.error,
  });
```
but to make it noob-friendly and obvious what has gone wrong without needing to consult log files, I've left the default to show errors in production.