### PR TITLE
docs: update branch to clone from

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@
 First, clone the repo via git:
 
 ```bash
-git clone --depth 1 --single-branch --branch master https://github.com/electron-react-boilerplate/electron-react-boilerplate.git your-project-name
+git clone --depth 1 --single-branch --branch next https://github.com/electron-react-boilerplate/electron-react-boilerplate.git your-project-name
 ```
 
 And then install the dependencies with yarn.


### PR DESCRIPTION
The instructions say to pull from `master` but it seems that `next` is the default advertised branch. Have we thought about updating the docs or is this intentional?