### PR TITLE
Update testcafe live runner and test titles

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "test": "cross-env NODE_ENV=test BABEL_DISABLE_CACHE=1 jest",
     "test-all": "yarn lint && yarn flow && yarn build && yarn test && yarn build-e2e && yarn test-e2e",
     "test-e2e": "node -r @babel/register ./internals/scripts/CheckBuildsExist.js && cross-env NODE_ENV=test testcafe electron:./app ./test/e2e/HomePage.e2e.js",
-    "test-e2e-live": "node -r @babel/register ./internals/scripts/CheckBuildsExist.js && cross-env NODE_ENV=test testcafe-live electron:./app ./test/e2e/HomePage.e2e.js",
+    "test-e2e-live": "node -r @babel/register ./internals/scripts/CheckBuildsExist.js && cross-env NODE_ENV=test testcafe --live electron:./app ./test/e2e/HomePage.e2e.js",
     "test-watch": "yarn test --watch"
   },
   "lint-staged": {
@@ -249,7 +249,6 @@
     "terser-webpack-plugin": "^2.2.1",
     "testcafe": "^1.6.1",
     "testcafe-browser-provider-electron": "^0.0.12",
-    "testcafe-live": "^0.1.4",
     "testcafe-react-selectors": "^3.3.0",
     "url-loader": "^2.2.0",
     "webpack": "^4.41.2",

--- a/test/e2e/HomePage.e2e.js
+++ b/test/e2e/HomePage.e2e.js
@@ -22,23 +22,23 @@ test('e2e', async t => {
   await t.expect(getPageTitle()).eql('Hello Electron React!');
 });
 
-test('should open window', async t => {
+test('should open window and contain expected page title', async t => {
   await t.expect(getPageTitle()).eql('Hello Electron React!');
 });
 
 test(
-  "should haven't any logs in console of main window",
+  'should not have any logs in console of main window',
   assertNoConsoleErrors
 );
 
-test('should to Counter with click "to Counter" link', async t => {
+test('should navigate to Counter with click on the "to Counter" link', async t => {
   await t
     .click('[data-tid=container] > a')
     .expect(getCounterText())
     .eql('0');
 });
 
-test('should navgiate to /counter', async t => {
+test('should navigate to /counter', async t => {
   await t
     .click('a')
     .expect(getPageUrl())
@@ -50,28 +50,28 @@ fixture`Counter Tests`
   .beforeEach(clickToCounterLink)
   .afterEach(assertNoConsoleErrors);
 
-test('should display updated count after increment button click', async t => {
+test('should display updated count after the increment button click', async t => {
   await t
     .click(incrementButton)
     .expect(getCounterText())
     .eql('1');
 });
 
-test('should display updated count after descrement button click', async t => {
+test('should display updated count after the descrement button click', async t => {
   await t
     .click(decrementButton)
     .expect(getCounterText())
     .eql('-1');
 });
 
-test('should not change if even and if odd button clicked', async t => {
+test('should not change even counter if odd button clicked', async t => {
   await t
     .click(oddButton)
     .expect(getCounterText())
     .eql('0');
 });
 
-test('should change if odd and if odd button clicked', async t => {
+test('should change odd counter if odd button clicked', async t => {
   await t
     .click(incrementButton)
     .click(oddButton)

--- a/yarn.lock
+++ b/yarn.lock
@@ -8758,11 +8758,6 @@ keyboardevents-areequal@^0.2.1:
   resolved "https://registry.yarnpkg.com/keyboardevents-areequal/-/keyboardevents-areequal-0.2.2.tgz#88191ec738ce9f7591c25e9056de928b40277194"
   integrity sha512-Nv+Kr33T0mEjxR500q+I6IWisOQ0lK1GGOncV0kWE6n4KFmpcu7RUX5/2B0EUtX51Cb0HjZ9VJsSY3u4cBa0kw==
 
-keypress@^0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/keypress/-/keypress-0.2.1.tgz#1e80454250018dbad4c3fe94497d6e67b6269c77"
-  integrity sha1-HoBFQlABjbrUw/6USX1uZ7YmnHc=
-
 keyv@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/keyv/-/keyv-3.0.0.tgz#44923ba39e68b12a7cec7df6c3268c031f2ef373"
@@ -13660,18 +13655,6 @@ testcafe-legacy-api@3.1.11:
     pify "^2.3.0"
     pinkie "^2.0.1"
     strip-bom "^2.0.0"
-
-testcafe-live@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/testcafe-live/-/testcafe-live-0.1.4.tgz#a5a24e0110267a5f3c99acefdbe593efaea510fc"
-  integrity sha512-ZDlj9GTkDU9XEEp7ds5nprzoBpVR2SQnz/u2PzZyyH7tOHLo5MRVC+wxSQBcgJzl2dBdiOaAsNsbPtyhOtrcRQ==
-  dependencies:
-    ansi-escapes "^3.0.0"
-    async-exit-hook "^2.0.1"
-    graphlib "^2.1.5"
-    keypress "^0.2.1"
-    log-update-async-hook "^2.0.2"
-    wrap-ansi "^3.0.1"
 
 testcafe-react-selectors@^3.3.0:
   version "3.3.0"


### PR DESCRIPTION
- Testcafe marked the testcafe-live as obsolete and points to using `--live` flag.
- Minor test names update