### PR TITLE
Clarify publicPath setting

### DIFF
--- a/configs/webpack.config.renderer.dev.babel.js
+++ b/configs/webpack.config.renderer.dev.babel.js
@@ -57,7 +57,7 @@ export default merge.smart(baseConfig, {
   ],
 
   output: {
-    publicPath: `http://localhost:${port}/dist/`,
+    publicPath: `${publicPath}/`,
     filename: 'renderer.dev.js'
   },
 


### PR DESCRIPTION
Seems like a trivial change but the "/" at the end of the path got me wrong when updating an old ERB app to Webpack 4, and debug tools do not catch this correctly (wrong `url` in css do not appear in the network tab or in the console so it's hard to detect).

By the way the `module` setup of the CSS seems to somehow break font awesome 4 import. I know this is probably a wontfix since you updated to font awesome v5. I still don't understand why it doesn't work but that's not a big deal.