### PR TITLE
Update package.json mac build option

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "package": "yarn build && electron-builder build --publish never",
     "package-all": "yarn build && electron-builder build -mwl",
     "package-ci": "yarn postinstall && yarn build && electron-builder --publish always",
+    "package-mac": "yarn build && electron-builder build --mac",
     "package-linux": "yarn build && electron-builder build --linux",
     "package-win": "yarn build && electron-builder build --win --x64",
     "postinstall": "node -r @babel/register internals/scripts/CheckNativeDep.js && electron-builder install-app-deps && yarn build-dll && opencollective-postinstall",


### PR DESCRIPTION
Hi, I'm proposing adding macOS `package-mac` build option into the package.json

This follows the pre-existing convention where they have specified individual builds for windows / linux.

Personally, I spent ~8mins trying to work out how to build to mac only.
Ended up running `package-linux`, `package-all`, `package`, downloaded 100+ mb of build stuff, then installed `brew install rpm` to get `package-linux` running.

I was wondering what might have prevented a new person from needlessly doing all that when experimenting.

I popped over to https://www.electron.build/configuration/configuration#configuration.

Decided that adding `package-mac` might have been better, so here I am :)