### PR TITLE
Fix TypeScript errors in menu.ts

### DIFF
--- a/app/menu.ts
+++ b/app/menu.ts
@@ -122,7 +122,7 @@ export default class MenuBuilder {
         }
       ]
     };
-    const subMenuViewProd = {
+    const subMenuViewProd: MenuItemConstructorOptions = {
       label: 'View',
       submenu: [
         {

--- a/app/menu.ts
+++ b/app/menu.ts
@@ -147,7 +147,7 @@ export default class MenuBuilder {
         { label: 'Bring All to Front', selector: 'arrangeInFront:' }
       ]
     } as MenuItemConstructorOptions;
-    const subMenuHelp = {
+    const subMenuHelp: MenuItemConstructorOptions = {
       label: 'Help',
       submenu: [
         {

--- a/app/menu.ts
+++ b/app/menu.ts
@@ -49,12 +49,11 @@ export default class MenuBuilder {
   }
 
   buildDarwinTemplate() {
-    const subMenuAbout: MenuItemConstructorOptions = {
+    const subMenuAbout = {
       label: 'Electron',
       submenu: [
         {
           label: 'About ElectronReact',
-          // @ts-ignore
           selector: 'orderFrontStandardAboutPanel:'
         },
         { type: 'separator' },
@@ -80,11 +79,10 @@ export default class MenuBuilder {
           }
         }
       ]
-    };
-    const subMenuEdit: MenuItemConstructorOptions = {
+    } as MenuItemConstructorOptions;
+    const subMenuEdit = {
       label: 'Edit',
       submenu: [
-        // @ts-ignore
         { label: 'Undo', accelerator: 'Command+Z', selector: 'undo:' },
         { label: 'Redo', accelerator: 'Shift+Command+Z', selector: 'redo:' },
         { type: 'separator' },
@@ -97,7 +95,7 @@ export default class MenuBuilder {
           selector: 'selectAll:'
         }
       ]
-    };
+    } as MenuItemConstructorOptions;
     const subMenuViewDev: MenuItemConstructorOptions = {
       label: 'View',
       submenu: [
@@ -124,7 +122,7 @@ export default class MenuBuilder {
         }
       ]
     };
-    const subMenuViewProd: MenuItemConstructorOptions = {
+    const subMenuViewProd = {
       label: 'View',
       submenu: [
         {
@@ -136,21 +134,20 @@ export default class MenuBuilder {
         }
       ]
     };
-    const subMenuWindow: MenuItemConstructorOptions = {
+    const subMenuWindow = {
       label: 'Window',
       submenu: [
         {
           label: 'Minimize',
           accelerator: 'Command+M',
-          // @ts-ignore
           selector: 'performMiniaturize:'
         },
         { label: 'Close', accelerator: 'Command+W', selector: 'performClose:' },
         { type: 'separator' },
         { label: 'Bring All to Front', selector: 'arrangeInFront:' }
       ]
-    };
-    const subMenuHelp: MenuItemConstructorOptions = {
+    } as MenuItemConstructorOptions;
+    const subMenuHelp = {
       label: 'Help',
       submenu: [
         {

--- a/app/menu.ts
+++ b/app/menu.ts
@@ -7,6 +7,11 @@ import {
   MenuItemConstructorOptions
 } from 'electron';
 
+interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions{
+  selector?: string;
+  submenu?: DarwinMenuItemConstructorOptions[] | Menu;
+}
+
 export default class MenuBuilder {
   mainWindow: BrowserWindow;
 
@@ -49,7 +54,7 @@ export default class MenuBuilder {
   }
 
   buildDarwinTemplate() {
-    const subMenuAbout = {
+    const subMenuAbout: DarwinMenuItemConstructorOptions = {
       label: 'Electron',
       submenu: [
         {
@@ -79,8 +84,8 @@ export default class MenuBuilder {
           }
         }
       ]
-    } as MenuItemConstructorOptions;
-    const subMenuEdit = {
+    };
+    const subMenuEdit: DarwinMenuItemConstructorOptions = {
       label: 'Edit',
       submenu: [
         { label: 'Undo', accelerator: 'Command+Z', selector: 'undo:' },
@@ -95,7 +100,7 @@ export default class MenuBuilder {
           selector: 'selectAll:'
         }
       ]
-    } as MenuItemConstructorOptions;
+    };
     const subMenuViewDev: MenuItemConstructorOptions = {
       label: 'View',
       submenu: [
@@ -134,7 +139,7 @@ export default class MenuBuilder {
         }
       ]
     };
-    const subMenuWindow = {
+    const subMenuWindow: DarwinMenuItemConstructorOptions = {
       label: 'Window',
       submenu: [
         {
@@ -146,7 +151,7 @@ export default class MenuBuilder {
         { type: 'separator' },
         { label: 'Bring All to Front', selector: 'arrangeInFront:' }
       ]
-    } as MenuItemConstructorOptions;
+    };
     const subMenuHelp: MenuItemConstructorOptions = {
       label: 'Help',
       submenu: [

--- a/app/menu.ts
+++ b/app/menu.ts
@@ -7,7 +7,7 @@ import {
   MenuItemConstructorOptions
 } from 'electron';
 
-interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions{
+interface DarwinMenuItemConstructorOptions extends MenuItemConstructorOptions {
   selector?: string;
   submenu?: DarwinMenuItemConstructorOptions[] | Menu;
 }


### PR DESCRIPTION
Apparently, MenuItemConstructorOptions.selector is a Darwin-only attribute.

![image](https://user-images.githubusercontent.com/47535238/77250842-3c6bbb00-6c53-11ea-95c9-2bdd085d1fa3.png)

TypeScript detects it and displays an error. To fix this error we can cast every menu that is using it to MenuItemConstructorOptions.
