### PR TITLE
Remove extraneous webpack-dev-server client from entries.

### DIFF
--- a/configs/webpack.config.renderer.dev.babel.js
+++ b/configs/webpack.config.renderer.dev.babel.js
@@ -50,7 +50,6 @@ export default merge.smart(baseConfig, {
 
   entry: [
     ...(process.env.PLAIN_HMR ? [] : ['react-hot-loader/patch']),
-    `webpack-dev-server/client?http://localhost:${port}/`,
     'webpack/hot/only-dev-server',
     require.resolve('../app/index.tsx')
   ],


### PR DESCRIPTION
As `webpack-dev-server` used for `yarn dev`, adding webpack-dev-server/client is not needed, only if we instantiate webpack-dev-server via nodejs api, afaik.
 