### PR TITLE
Remove unnecessary file extensions from ts exclude

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,14 +26,9 @@
     "test",
     "release",
     "app/main.prod.js",
-    "app/main.prod.js.map",
     "app/renderer.prod.js",
-    "app/renderer.prod.js.map",
-    "app/style.css",
-    "app/style.css.map",
     "app/dist",
     "dll",
-    "app/main.js",
-    "app/main.js.map"
+    "app/main.js"
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -28,7 +28,6 @@
     "app/main.prod.js",
     "app/renderer.prod.js",
     "app/dist",
-    "dll",
-    "app/main.js"
+    "dll"
   ]
 }


### PR DESCRIPTION
Removed `.css` and `.map` files from `tsconfig.json`. They aren't considered anyways during `tsc` execution (according to [typescript documentation](https://www.typescriptlang.org/docs/handbook/tsconfig-json.html#details))

> If the "files" and "include" are both left unspecified, the compiler defaults to including all TypeScript (.ts, .d.ts and .tsx) files in the containing directory and subdirectories except those excluded using the "exclude" property. JS files (.js and .jsx) are also included if allowJs is set to true.
