### PR TITLE
fix eslint ignore

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -50,6 +50,6 @@ __snapshots__
 # Package.json
 package.json
 .travis.yml
-*.css.d.ts
-*.sass.d.ts
-*.scss.d.ts
+*css.d.ts
+*sass.d.ts
+*scss.d.ts


### PR DESCRIPTION
Files that aren't supposed to be linted were being linted. Was causing linting problems in eslint-plugin-compat benchmarks. 

Before and after `yarn lint --debug`:

![image](https://user-images.githubusercontent.com/15751908/85214238-45852a80-b31d-11ea-95a9-33a63b3c733d.png)
