### PR TITLE
Fix e2e test error

### DIFF
--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -110,7 +110,12 @@ app.on('window-all-closed', () => {
   }
 });
 
-app.on('ready', createWindow);
+if (process.env.E2E_BUILD === 'true') {
+  // eslint-disable-next-line promise/catch-or-return
+  app.whenReady().then(createWindow);
+} else {
+  app.on('ready', createWindow);
+}
 
 app.on('activate', () => {
   // On macOS it's common to re-create a window in the app when the

--- a/configs/webpack.config.renderer.prod.babel.js
+++ b/configs/webpack.config.renderer.prod.babel.js
@@ -21,7 +21,7 @@ export default merge.smart(baseConfig, {
 
   mode: 'production',
 
-  target: 'electron-preload',
+  target: process.env.E2E_BUILD ? 'electron-renderer' : 'electron-preload',
 
   entry: path.join(__dirname, '..', 'app/index.tsx'),
 


### PR DESCRIPTION
**1. App is not showing up**
When I try `yarn build-e2e` and `yarn test-e2e`, app doesn't show up because `app.on('ready')` event is not fired after electron is executed by testcafe. After I use `whenReady()` instead of `on('read')` it works fine.


**2. Webpack Dynamic Imports not working properly**
After electron is launched by testcafe, app can't load `CounterPage` component because script is trying to reference `/app` path instead of `/app/dist/` and showing javascript error below.
```
JavaScript error details:
      Error: ENOENT: no such file or directory, open '/User-Directory-Path/electron-react-boilerplate/app/0.renderer.prod.js'
```
However after I build app with `electron-renderer` target not `electron-preload`, dynamic imports works well.

If you know the better way to fix error about e2e test, please edit the code.