### PR TITLE
fix scss compile error (#2523)

### DIFF
--- a/configs/webpack.config.renderer.dev.babel.js
+++ b/configs/webpack.config.renderer.dev.babel.js
@@ -118,10 +118,10 @@ export default merge(baseConfig, {
         test: /^((?!\.global).)*\.(scss|sass)$/,
         use: [
           {
-            loader: 'typings-for-css-modules-loader',
+            loader: 'style-loader',
           },
           {
-            loader: 'typings-for-css-modules-loader',
+            loader: 'css-loader',
             options: {
               modules: {
                 localIdentName: '[name]__[local]__[hash:base64:5]',

--- a/package.json
+++ b/package.json
@@ -287,6 +287,7 @@
     "redux": "^4.0.5",
     "redux-thunk": "^2.3.0",
     "regenerator-runtime": "^0.13.5",
+    "sass": "^1.26.10",
     "source-map-support": "^0.5.19"
   },
   "devEngines": {


### PR DESCRIPTION
the `typings-for-css-modules-loader` package is deprecated and not maintain any more. and cause below error when using scss files: 

```bash
Module build failed (from ./node_modules/typings-for-css-modules-loader/lib/index.js):
Error: Cannot find module 'css-loader/locals'
```

issue #2523 