### PR TITLE
Change renovate baseBranch to `next`

### DIFF
--- a/package.json
+++ b/package.json
@@ -325,7 +325,8 @@
   "renovate": {
     "extends": [
       "bliss"
-    ]
+    ],
+    "baseBranches": ["next"]
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
I believe it makes more sense to have dependency updates in `next` rather than master