### PR TITLE
Provide default app icon

### DIFF
--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -56,10 +56,19 @@ const createWindow = async () => {
     await installExtensions();
   }
 
+  const RESOURCES_PATH = app.isPackaged
+    ? path.join(process.resourcesPath, 'resources')
+    : path.join(__dirname, '../resources');
+
+  const getAssetPath = (...paths: string[]): string => {
+    return path.join(RESOURCES_PATH, ...paths);
+  };
+
   mainWindow = new BrowserWindow({
     show: false,
     width: 1024,
     height: 728,
+    icon: getAssetPath('icon.png'),
     webPreferences:
       (process.env.NODE_ENV === 'development' ||
         process.env.E2E_BUILD === 'true') &&

--- a/package.json
+++ b/package.json
@@ -94,6 +94,9 @@
       "buildResources": "resources",
       "output": "release"
     },
+    "extraResources": [
+      "./resources/**"
+    ],
     "publish": {
       "provider": "github",
       "owner": "electron-react-boilerplate",


### PR DESCRIPTION
This adds the default app icon to the boilerplate.

Based on https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/2511