### PR TITLE
adds cross-env as dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -215,7 +215,7 @@
     "chalk": "^4.1.0",
     "concurrently": "^5.3.0",
     "core-js": "^3.6.5",
-    "cross-env": "^7.0.0",
+    "cross-env": "^7.0.2",
     "css-loader": "^3.6.0",
     "detect-port": "^1.3.0",
     "electron": "^8",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4690,7 +4690,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-env@^7.0.0:
+cross-env@^7.0.2:
   version "7.0.2"
   resolved "https://registry.yarnpkg.com/cross-env/-/cross-env-7.0.2.tgz#bd5ed31339a93a3418ac4f3ca9ca3403082ae5f9"
   integrity sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==


### PR DESCRIPTION
I tried to use this boilerplate on Windows and it failed. I know cross-env is usually a global, but if it is not on the system already, it is needed.