### PR TITLE
chore: improve devtools installer usage

### DIFF
--- a/app/main.dev.ts
+++ b/app/main.dev.ts
@@ -43,9 +43,12 @@ const installExtensions = async () => {
   const forceDownload = !!process.env.UPGRADE_EXTENSIONS;
   const extensions = ['REACT_DEVELOPER_TOOLS', 'REDUX_DEVTOOLS'];
 
-  return Promise.all(
-    extensions.map((name) => installer.default(installer[name], forceDownload))
-  ).catch(console.log);
+  return installer
+    .default(
+      extensions.map((name) => installer[name]),
+      forceDownload
+    )
+    .catch(console.log);
 };
 
 const createWindow = async () => {


### PR DESCRIPTION
It seems that the [electron-devtools-installer](https://github.com/MarshallOfSound/electron-devtools-installer) supports install multiple extensions when passing first argument as array, so there's no need that we do that `promise.all` mapping. Just a tiny improvement which makes it slightly clearer.