### PR TITLE
Makes git automatically converting LF to CRLF and vice versa depending on system

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-* text eol=lf
+* text=auto
 *.png binary
 *.jpg binary
 *.jpeg binary

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
-* text=auto
-*.png binary
-*.jpg binary
-*.jpeg binary
-*.ico binary
-*.icns binary
+*       text    eol=lf
+*.exe   binary
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.ico   binary
+*.icns  binary


### PR DESCRIPTION
Hi! First of all thanks for your excellent work. Its really saves time. 

I faced with line ending issue with setting from `.gitattributes` - `* text eol=lf`. Point is that when git makes force line endings convertion from CRLF to LF it can break down `.exe` file. It wouldn't work with following output. 
```
Program 'Senso_DK3_connector.exe' failed to run: The specified executable is not a valid application for this OS platform.At line:1 char:1
+ C:\Users\alex\Projects\frontend-desktop\app\infrastructure\drivers\dk ...
At line:1 char:1
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + FullyQualifiedErrorId : NativeCommandFailed
``` 

I suggest makes git handle line endings convertion automatically depending on current system to avoid such issue. 

Thanks.