### PR TITLE
Replace the deprecated NamedModulesPlugin with the optimization.named…

### DIFF
--- a/configs/webpack.config.base.js
+++ b/configs/webpack.config.base.js
@@ -38,11 +38,13 @@ export default {
     modules: [path.join(__dirname, '..', 'app'), 'node_modules'],
   },
 
+  optimization: {
+    namedModules: true,
+  },
+
   plugins: [
     new webpack.EnvironmentPlugin({
       NODE_ENV: 'production',
     }),
-
-    new webpack.NamedModulesPlugin(),
   ],
 };

--- a/configs/webpack.config.renderer.prod.babel.js
+++ b/configs/webpack.config.renderer.prod.babel.js
@@ -21,7 +21,7 @@ export default merge(baseConfig, {
 
   mode: 'production',
 
-  target: process.env.E2E_BUILD ? 'electron-renderer' : 'electron-preload',
+  target: process.env.E2E_BUILD || process.env.ERB_SECURE !== 'true' ? 'electron-renderer' : 'electron-preload',
 
   entry: [
     'core-js',


### PR DESCRIPTION
NamedModulesPlugin was deprecated in webpack v4.

The optimization.namedModules set to true serves the same thing.
