### PR TITLE
Correct `assets` directory name in main.dev.ts file

### DIFF
--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -60,8 +60,8 @@ const createWindow = async () => {
   }
 
   const RESOURCES_PATH = app.isPackaged
-    ? path.join(process.resourcesPath, 'resources')
-    : path.join(__dirname, '../resources');
+    ? path.join(process.resourcesPath, 'assets')
+    : path.join(__dirname, '../assets');
 
   const getAssetPath = (...paths: string[]): string => {
     return path.join(RESOURCES_PATH, ...paths);


### PR DESCRIPTION
Correct **assets** directory name in _main.dev.ts_ file (previously it was **resources**).