### PR TITLE
Stopping script from processing if there are no native dependencies

### DIFF
--- a/.erb/scripts/CheckNativeDep.js
+++ b/.erb/scripts/CheckNativeDep.js
@@ -8,6 +8,9 @@ if (dependencies) {
   const nativeDeps = fs
     .readdirSync('node_modules')
     .filter((folder) => fs.existsSync(`node_modules/${folder}/binding.gyp`));
+  if (nativeDeps.length === 0) {
+    process.exit(0);
+  }
   try {
     // Find the reason for why the dependency is installed. If it is installed
     // because of a devDependency then that is okay. Warn when it is installed


### PR DESCRIPTION
If the scan of the **node_modules** reveals no dependencies with binding.gyp files, there is no reason for processing the script further. 

More important, if there are no native dependencies,  line 16 is returning a list of all of the dependencies in the project.
Scripts then fails, reporting incorrect libraries as being native.
