### PR TITLE
fix: incorrect cursor style on button

### DIFF
--- a/src/App.global.css
+++ b/src/App.global.css
@@ -22,7 +22,6 @@ body {
 button {
   background-color: white;
   padding: 10px 20px;
-  margin: 10px;
   border-radius: 10px;
   border: none;
   appearance: none;
@@ -30,6 +29,7 @@ button {
   box-shadow: 0px 8px 28px -6px rgba(24, 39, 75, 0.12),
     0px 18px 88px -4px rgba(24, 39, 75, 0.14);
   transition: transform ease-in 0.1s;
+  cursor: pointer;
 }
 
 button:hover {
@@ -42,12 +42,14 @@ li {
 
 a {
   text-decoration: none;
+  height: fit-content;
+  width: fit-content;
+  margin: 10px;
 }
 
 a:hover {
   opacity: 1;
   text-decoration: none;
-  cursor: pointer;
 }
 
 .Hello {


### PR DESCRIPTION
This fixes to small style issues:

1. The cursor style on the buttons is styled incorrectly: it becomes unset when hovering directly over button. 
2. We are able to go to a link when clicking in empty space (because the link span is larger than the button).
