### PR TITLE
fix: correcting references to names of package scripts

### DIFF
--- a/.erb/scripts/CheckBuildsExist.js
+++ b/.erb/scripts/CheckBuildsExist.js
@@ -11,7 +11,7 @@ const rendererPath = path.join(
 if (!fs.existsSync(mainPath)) {
   throw new Error(
     chalk.whiteBright.bgRed.bold(
-      'The main process is not built yet. Build it by running "yarn build-main"'
+      'The main process is not built yet. Build it by running "yarn build:main"'
     )
   );
 }
@@ -19,7 +19,7 @@ if (!fs.existsSync(mainPath)) {
 if (!fs.existsSync(rendererPath)) {
   throw new Error(
     chalk.whiteBright.bgRed.bold(
-      'The renderer process is not built yet. Build it by running "yarn build-renderer"'
+      'The renderer process is not built yet. Build it by running "yarn build:renderer"'
     )
   );
 }

--- a/src/main.dev.ts
+++ b/src/main.dev.ts
@@ -5,7 +5,7 @@
  * electron renderer process from here and communicate with the other processes
  * through IPC.
  *
- * When running `yarn build` or `yarn build-main`, this file is compiled to
+ * When running `yarn build` or `yarn build:main`, this file is compiled to
  * `./src/main.prod.js` using webpack. This gives us some performance wins.
  */
 import 'core-js/stable';


### PR DESCRIPTION
Small fix to some references to the package scripts, which I'm guessing have been renamed at some point possibly