### PR TITLE
Fix for unknown module eslint config

### DIFF
--- a/.erb/configs/webpack.config.eslint.js
+++ b/.erb/configs/webpack.config.eslint.js
@@ -1,4 +1,4 @@
 /* eslint import/no-unresolved: off, import/no-self-import: off */
-require('../.erb/scripts/node_modules/@babel/register');
+require('@babel/register');
 
 module.exports = require('./webpack.config.renderer.dev.babel').default;


### PR DESCRIPTION
I got an unknown module error when executing yarn lint because the require in file webpack.config.eslint.js was referencing a non-existent node_module folder. The error was fixed by not hard-coding the path to the module.