### PR TITLE
Save yarn cache dir between builds

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [ macos-latest ]
 
     steps:
       - name: Checkout git repo
@@ -21,6 +21,22 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: 15
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v1
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install dependencies
+        run: |
+          yarn install --prefer-offline
 
       - name: Install dependencies
         run: |


### PR DESCRIPTION
We use this boilerplate at [ExpressLRS Configurator](https://github.com/ExpressLRS/ExpressLRS-Configurator) and this change improved our build pipeline reliability and reduced built time.

With this change, we cache yarn modules cache dir. During the next builds yarn loads modules from cache first and if it fails it fallbacks to the network.