### PR TITLE
resolved issue with document.write() script injection

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -33,11 +33,13 @@
       }
 
       if (scripts.length) {
-        document.write(
-          scripts
-            .map((script) => `<script defer src="${script}"><\/script>`)
-            .join('')
-        );
+        const body = document.querySelector('body');
+        scripts.forEach((script) => {
+          const newScript = document.createElement('script');
+          newScript.setAttribute('defer', true);
+          newScript.setAttribute('src', script);
+          body.appendChild(newScript);
+        });
       }
     </script>
   </body>

--- a/src/index.html
+++ b/src/index.html
@@ -36,7 +36,7 @@
         const body = document.querySelector('body');
         scripts.forEach((script) => {
           const newScript = document.createElement('script');
-          newScript.setAttribute('defer', true);
+          newScript.setAttribute('defer', '');
           newScript.setAttribute('src', script);
           body.appendChild(newScript);
         });


### PR DESCRIPTION
This PR resolves the following issue.
When running the boilerplate in development, the following warning can be seen in the console:
```bash
[Violation] Avoid using document.write(). https://developers.google.com/web/updates/2016/08/removing-document-write
```
This is due to the usage of document.write() within the index.html file. Per the above doc, document.write() is parser blocking which means even if defer is passed in, the write will still execute and block the page rendering. 

After my fix, I tested that I am still getting the appropriate script tags included with the defer tags as previously implemented without warnings.
![image](https://user-images.githubusercontent.com/33189296/112930927-31aaf800-90e9-11eb-8b21-6706d1541e40.png)
