### PR TITLE
feat: update webpack.config.renderer.dev.babel.js

### DIFF
--- a/.erb/configs/webpack.config.renderer.dev.babel.js
+++ b/.erb/configs/webpack.config.renderer.dev.babel.js
@@ -31,7 +31,7 @@ if (!requiredByDLLConfig && !(fs.existsSync(dllDir) && fs.existsSync(manifest)))
       'The DLL files are missing. Sit back while we build them for you with "yarn build-dll"'
     )
   );
-  execSync('yarn');
+  execSync('yarn postinstall');
 }
 
 export default merge(baseConfig, {

--- a/.erb/configs/webpack.config.renderer.dev.babel.js
+++ b/.erb/configs/webpack.config.renderer.dev.babel.js
@@ -31,7 +31,7 @@ if (!requiredByDLLConfig && !(fs.existsSync(dllDir) && fs.existsSync(manifest)))
       'The DLL files are missing. Sit back while we build them for you with "yarn build-dll"'
     )
   );
-  execSync('yarn build-dll');
+  execSync('yarn');
 }
 
 export default merge(baseConfig, {


### PR DESCRIPTION
The 'yarn build-dll' directive does not exist,simply execute 'yarn '.