### PR TITLE
feat: migrate to memory router

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Switch, Route } from 'react-router-dom';
+import { MemoryRouter, Switch, Route } from 'react-router-dom';
 import icon from '../../assets/icon.svg';
 import './App.global.css';
 
@@ -42,10 +42,10 @@ const Hello = () => {
 
 export default function App() {
   return (
-    <Router>
+    <MemoryRouter>
       <Switch>
         <Route path="/" component={Hello} />
       </Switch>
-    </Router>
+    </MemoryRouter>
   );
 }


### PR DESCRIPTION
A <Router> that keeps the history of your “URL” in memory (does not read or write to the address bar). Environments like React Native use it and I believe this is the right way to do routing with React in Electron.