### PR TITLE
Update README and bug report issue template to recommend correct branch

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-Bug_report.md
+++ b/.github/ISSUE_TEMPLATE/1-Bug_report.md
@@ -11,7 +11,7 @@ labels: 'bug'
 <!-- If the following boxes are not ALL checked, your issue is likely to be closed -->
 
 - [ ] Using yarn
-- [ ] Using an up-to-date [`master` branch](https://github.com/electron-react-boilerplate/electron-react-boilerplate/tree/master)
+- [ ] Using an up-to-date [`main` branch](https://github.com/electron-react-boilerplate/electron-react-boilerplate/tree/main)
 - [ ] Using latest version of devtools. [Check the docs for how to update](https://electron-react-boilerplate.js.org/docs/dev-tools/)
 - [ ] Tried solutions mentioned in [#400](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/400)
 - [ ] For issue in production release, add devtools output of `DEBUG_PROD=true yarn build && yarn start`

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 First, clone the repo via git and install dependencies:
 
 ```bash
-git clone --depth 1 --single-branch https://github.com/electron-react-boilerplate/electron-react-boilerplate.git your-project-name
+git clone --depth 1 --branch main https://github.com/electron-react-boilerplate/electron-react-boilerplate.git your-project-name
 cd your-project-name
 yarn
 ```


### PR DESCRIPTION
Addresses https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/2909

Also updates the README to use the `main` branch instead of `--single-branch' so it matches the instructions in the template, although the end result is the same.