### PR TITLE
Load the `/` path, instead of `/index.html`

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -84,7 +84,7 @@ const createWindow = async () => {
     },
   });
 
-  mainWindow.loadURL(resolveHtmlPath('index.html'));
+  mainWindow.loadURL(resolveHtmlPath(''));
 
   // @TODO: Use 'ready-to-show' event
   //        https://github.com/electron/electron/blob/main/docs/api/browser-window.md#using-ready-to-show-event


### PR DESCRIPTION
If you use react-router, having `exact` on `/` will not render anything on `/index.html`.
Removing `index.html` will still load it since it searches for `index.`[`html`,`php`] when loading, and give `/` as the path for react router.