### PR TITLE
Fix PORT env var not passed to webpack.config.renderer

### DIFF
--- a/.erb/configs/webpack.config.renderer.dev.babel.js
+++ b/.erb/configs/webpack.config.renderer.dev.babel.js
@@ -46,7 +46,7 @@ export default merge(baseConfig, {
   target: ['web', 'electron-renderer'],
 
   entry: [
-    'webpack-dev-server/client?http://localhost:1212/dist',
+    `webpack-dev-server/client?http://localhost:${port}/dist`,
     'webpack/hot/only-dev-server',
     'core-js',
     'regenerator-runtime/runtime',


### PR DESCRIPTION
This fixes a bug whereby changing the port from 1212 -> 4343 for example leads to errors such as:
`Failed to load resource: net::ERR_CONNECTION_REFUSED    :1212/sockjs-node/info?t=1631071460786:1 `

In the electron browser console. Because it is still using port 1212.