### PR TITLE
Make use of previously created `isDevelopment` constant

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -59,10 +59,7 @@ const installExtensions = async () => {
 };
 
 const createWindow = async () => {
-  if (
-    process.env.NODE_ENV === 'development' ||
-    process.env.DEBUG_PROD === 'true'
-  ) {
+  if (isDevelopment) {
     await installExtensions();
   }
 


### PR DESCRIPTION
Constant `isDevelopment` wasn't used in `createWindow` function.