### PR TITLE
Bump Electron to 13.5.1 to fix SSL certificate problem with Let's Encrypt

### DIFF
--- a/package.json
+++ b/package.json
@@ -176,7 +176,7 @@
     "css-loader": "^6.2.0",
     "css-minimizer-webpack-plugin": "^3.0.2",
     "detect-port": "^1.3.0",
-    "electron": "^13.2.1",
+    "electron": "^13.5.1",
     "electron-builder": "^22.11.7",
     "electron-devtools-installer": "^3.2.0",
     "electron-notarize": "^1.1.0",


### PR DESCRIPTION
Hi, since yesterday, all apps around the world suffered a problem with Let's Encrypt; suddenly Electron couldn't recognize Let's Encrypt as a secure certificate, and led to errors like "Certificate has expired".

It started happened to me as well.

Here's the PR that the Electron team created yesterday, which's merged into 13.5.1:
https://github.com/electron/electron/pull/31216

More info of users having the problem:
https://github.com/electron/electron/issues/31212