### PR TITLE
Fix: enable 'activate' handler only after app is Ready

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -127,10 +127,13 @@ app.on('window-all-closed', () => {
   }
 });
 
-app.whenReady().then(createWindow).catch(console.log);
+app.whenReady().then(() => {
+  createWindow()
 
-app.on('activate', () => {
-  // On macOS it's common to re-create a window in the app when the
-  // dock icon is clicked and there are no other windows open.
-  if (mainWindow === null) createWindow();
-});
+  app.on('activate', () => {
+    // On macOS it's common to re-create a window in the app when the
+    // dock icon is clicked and there are no other windows open.
+    if (mainWindow === null) createWindow();
+  });
+
+}).catch(console.log);


### PR DESCRIPTION
This prevents the issue where electron throws the `cannot create BrowserWindow` before app is ready exception, when the user clicks the app icon before it is ready.