### PR TITLE
Fix cross-env CLI commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "ts-node ./.erb/scripts/check-port-in-use.js && npm run start:renderer",
     "start:main": "cross-env NODE_ENV=development electron -r ts-node/register/transpile-only ./src/main/main.ts",
     "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",
-    "test": "jest"
+    "test": "jest",
+    "cross-env": "cross-env"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
Since the migration to npm the CLI commands with `cross-env` are not working. <https://electron-react-boilerplate.js.org/docs/packaging>

For instance, `npm run cross-env DEBUG_PROD=true npm run package` fails  with:

```
npm ERR! Missing script: "cross-env"
npm ERR!
npm ERR! To see a list of scripts, run:
npm ERR!   npm run
```

 This PR adds a new script to make those commands work again.