### PR TITLE
Fix: Paths when importing webpackPaths.

### DIFF
--- a/.erb/scripts/link-modules.ts
+++ b/.erb/scripts/link-modules.ts
@@ -1,8 +1,8 @@
 import fs from 'fs';
-import {
-  appNodeModulesPath,
-  srcNodeModulesPath,
-} from '../configs/webpack.paths';
+import webpackPaths from '../configs/webpack.paths';
+
+const srcNodeModulesPath = webpackPaths.srcNodeModulesPath;
+const appNodeModulesPath = webpackPaths.appNodeModulesPath
 
 if (!fs.existsSync(srcNodeModulesPath) && fs.existsSync(appNodeModulesPath)) {
   fs.symlinkSync(appNodeModulesPath, srcNodeModulesPath, 'junction');

--- a/release/app/package.json
+++ b/release/app/package.json
@@ -11,7 +11,7 @@
   },
   "scripts": {
     "electron-rebuild": "node -r ts-node/register ../../.erb/scripts/electron-rebuild.js",
-    "link-modules": "node -r ts-node/register ../../.erb/scripts/link-modules.js",
+    "link-modules": "node -r ts-node/register ../../.erb/scripts/link-modules.ts",
     "postinstall": "npm run electron-rebuild && npm run link-modules"
   },
   "license": "MIT"


### PR DESCRIPTION
This PR allows to use native modules again. Since the default export is an object, the previous version would use undefined instead of the real paths.