### PR TITLE
Fixing husky configuration after moving from husky v4 to husky v7

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+. "$(dirname "$0")/_/husky.sh"
+
+npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,7 +63,7 @@
         "eslint-plugin-react-hooks": "^4.2.0",
         "file-loader": "^6.2.0",
         "html-webpack-plugin": "^5.5.0",
-        "husky": "7.0.4",
+        "husky": "^7.0.0",
         "identity-obj-proxy": "^3.0.0",
         "jest": "^27.3.1",
         "lint-staged": "^11.2.6",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "start": "ts-node ./.erb/scripts/check-port-in-use.js && npm run start:renderer",
     "start:main": "cross-env NODE_ENV=development electron -r ts-node/register/transpile-only ./src/main/main.ts",
     "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",
-    "test": "jest"
+    "test": "jest",
+    "prepare": "husky install"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [
@@ -204,7 +205,7 @@
     "eslint-plugin-react-hooks": "^4.2.0",
     "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",
-    "husky": "7.0.4",
+    "husky": "^7.0.0",
     "identity-obj-proxy": "^3.0.0",
     "jest": "^27.3.1",
     "lint-staged": "^11.2.6",
@@ -261,10 +262,5 @@
       }
     ],
     "singleQuote": true
-  },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
   }
 }


### PR DESCRIPTION
Husky did not execute anymore on pre-commit. There seems to have been a breaking change in how husky needs to be configured. 

I have used [typicode/husky-4-to-7](https://github.com/typicode/husky-4-to-7) to convert the existing configuration. Now everything works again as usual.

