### PR TITLE
Fix: compare env variable to string

### DIFF
--- a/.erb/scripts/notarize.js
+++ b/.erb/scripts/notarize.js
@@ -7,7 +7,7 @@ exports.default = async function notarizeMacos(context) {
     return;
   }
 
-  if (!process.env.CI) {
+  if (process.env.CI !== "true") {
     console.warn('Skipping notarizing step. Packaging is not running in CI');
     return;
   }


### PR DESCRIPTION
env variables are always strings, so doing not on a string only checks that CI has any value, meaning CI=false would not skip notarizing.