### PR TITLE
feat: add `public` resource support

### DIFF
--- a/.erb/configs/webpack.config.renderer.dev.ts
+++ b/.erb/configs/webpack.config.renderer.dev.ts
@@ -159,6 +159,8 @@ const configuration: webpack.Configuration = {
     headers: { 'Access-Control-Allow-Origin': '*' },
     static: {
       publicPath: '/',
+      // add `public` support for devServer
+      directory: path.join(webpackPaths.appPath),
     },
     historyApiFallback: {
       verbose: true,

--- a/package.json
+++ b/package.json
@@ -37,7 +37,11 @@
     "files": [
       "dist",
       "node_modules",
-      "package.json"
+      "package.json",
+      {
+        "from": "public",
+        "to": "dist/renderer/public"
+      }
     ],
     "afterSign": ".erb/scripts/notarize.js",
     "mac": {

--- a/release/app/public/other-bundle-file.js
+++ b/release/app/public/other-bundle-file.js
@@ -1,0 +1,1 @@
+console.log("this is a other bundle file use like public resource that no need to pack.")

--- a/src/renderer/index.ejs
+++ b/src/renderer/index.ejs
@@ -18,4 +18,6 @@
 
     window.electron.ipcRenderer.myPing();
   </script>
+  <!-- load some `public` resource that no need to pack. -->
+  <script src="./public/other-bundle-file.js"></script>
 </html>


### PR DESCRIPTION
sometimes we want to use `public` resource maybe came from other that no need to pack.
I try this for my work, and think other people need it, too.
may close these:
[issues#3107](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/3107)
[issues#3117](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/3117)
[issues#3077](https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/3077)