### PR TITLE
fix: use setWindowOpenHandler

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -102,9 +102,9 @@ const createWindow = async () => {
   menuBuilder.buildMenu();
 
   // Open urls in the user's browser
-  mainWindow.webContents.on('new-window', (event, url) => {
-    event.preventDefault();
-    shell.openExternal(url);
+  mainWindow.webContents.setWindowOpenHandler(edata => {
+    shell.openExternal(edata.url);
+    return { action: 'deny' };
   });
 
   // Remove this if your app does not use auto updates


### PR DESCRIPTION
on('new-window', (event,url)=>...) is deprecated in favor of setWindowOpenHandler.
This fixes a potential future bug if (and when) the new-window event is removed, by moving to setWindowOpenHandler.