### PR TITLE
Fix typescript webpack errors

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,8 @@
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,
     "allowJs": true,
-    "outDir": "release/app/dist"
+    "outDir": "release/app/dist",
+    "types": ["node"]
   },
   "exclude": ["test", "release/build", "release/app/dist", ".erb/dll"]
 }


### PR DESCRIPTION
The webpack configuration did not compile because of  `Cannot find name 'require'` and `Cannot find name '__dirname'`.
This has now been fixed.