### PR TITLE
Fix: vscode debugging

### DIFF
--- a/.erb/configs/webpack.config.renderer.dev.ts
+++ b/.erb/configs/webpack.config.renderer.dev.ts
@@ -161,16 +161,6 @@ const configuration: webpack.Configuration = {
     historyApiFallback: {
       verbose: true,
     },
-    onBeforeSetupMiddleware() {
-      console.log('Starting Main Process...');
-      spawn('npm', ['run', 'start:main'], {
-        shell: true,
-        env: process.env,
-        stdio: 'inherit',
-      })
-        .on('close', (code: number) => process.exit(code!))
-        .on('error', (spawnError) => console.error(spawnError));
-    },
   },
 };
 

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -7,9 +7,7 @@
       "request": "launch",
       "protocol": "inspector",
       "runtimeExecutable": "npm",
-      "runtimeArgs": [
-        "run start:main --inspect=5858 --remote-debugging-port=9223"
-      ],
+      "runtimeArgs": ["run", "start:main:debug"],
       "preLaunchTask": "Start Webpack Dev"
     },
     {

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,8 +16,8 @@
         },
         "background": {
           "activeOnStart": true,
-          "beginsPattern": "Compiling\\.\\.\\.$",
-          "endsPattern": "(Compiled successfully|Failed to compile)\\.$"
+          "beginsPattern": ".",
+          "endsPattern": "Project is running at:$"
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,9 @@
     "lint": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx",
     "package": "ts-node ./.erb/scripts/clean.js dist && npm run build && electron-builder build --publish never",
     "postinstall": "ts-node .erb/scripts/check-native-dep.js && electron-builder install-app-deps && cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.dev.dll.ts && opencollective-postinstall",
-    "start": "ts-node ./.erb/scripts/check-port-in-use.js && npm run start:renderer",
+    "start": "ts-node ./.erb/scripts/check-port-in-use.js && concurrently \"npm run start:renderer\" \"npm run start:main\"",
     "start:main": "cross-env NODE_ENV=development electron -r ts-node/register/transpile-only ./src/main/main.ts",
+    "start:main:debug": "cross-env NODE_ENV=development electron -r ts-node/register/transpile-only ./src/main/main.ts --inspect=5858 --remote-debugging-port=9223",
     "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",
     "test": "jest",
     "prepare": "husky install"


### PR DESCRIPTION
Fixes #428

Explanation of changes:
As mentioned in #428, "Start Webpack Dev" has an out of date "endsPattern", so when used as a preLaunchTask it would prevent the next part of the launch configuration from running. It has been changed here to search for part of what is now webpack's only output.

While I am unfamiliar with yarn, I have a hunch that it offers you the option to pass arguments to scripts as was previously done in `launch.json`, but with npm that no longer seems to work. The way this pull request tackles that is to add a new `start:main:debug` script which includes the debugging arguments.

Additionally, the webpack configuration for the renderer has been changed so that it no longer automatically launches the main process as well, as this would cause the existing debug configuration to launch the main process twice, and once without the debug arguments. The start script which relied on this behavior has been changed.


This is my first-crack at fixing this issue, and I am new to this type of project, so if there are suggestions for improvements, I would love to hear and implement them. <3