### PR TITLE
fix: rename GITHUB_TOKEN to GH_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -39,7 +39,7 @@ jobs:
           CSC_LINK: ${{ secrets.CSC_LINK }}
           CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
           # This is used for uploading release assets to github
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           npm run postinstall
           npm run build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: npm test
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: |
           npm run package
           npm run lint


### PR DESCRIPTION
Github does not allow secrets to start with `GITHUB_`. 
Changed to `GH_TOKEN` because electron-builder uses that name by default.

![github_](https://user-images.githubusercontent.com/3721291/160919914-9e73ea05-df19-45c6-accc-3fc107c97ddf.png)
