### PR TITLE
fix electron broken start

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "electron-react-boilerplate",
   "description": "A foundation for scalable desktop apps",
+  "main": "./src/main/main.ts",
   "scripts": {
     "build": "concurrently \"npm run build:main\" \"npm run build:renderer\"",
     "build:main": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.main.prod.ts",
@@ -10,7 +11,7 @@
     "package": "ts-node ./.erb/scripts/clean.js dist && npm run build && electron-builder build --publish never",
     "postinstall": "ts-node .erb/scripts/check-native-dep.js && electron-builder install-app-deps && cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.dev.dll.ts && opencollective-postinstall",
     "start": "ts-node ./.erb/scripts/check-port-in-use.js && npm run start:renderer",
-    "start:main": "cross-env NODE_ENV=development electronmon -r ts-node/register/transpile-only ./src/main/main.ts",
+    "start:main": "cross-env NODE_ENV=development electronmon -r ts-node/register/transpile-only .",
     "start:preload": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.preload.dev.ts",
     "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",
     "test": "jest",


### PR DESCRIPTION
Start electron like this `electron ./src/main/main.ts` brokes many electron apis:
- `app.getVersion()` - returns version of electron like `18.0.1` instead of `packages.version`
- `app.getPath("userData")` return `%appdata%/Electron` instead of `%appdata%/${package.name}`, i though it was intended behaviour to split up development version from production but looks like its not🙃 just error that appeared long ago 
![Снимок экрана 2022-05-02 171916](https://user-images.githubusercontent.com/14001879/166255623-e726a074-9117-453a-9711-e5573307eb58.png)


That behaviour brokes many libraries dependent on `app.getVersion` e.g. in `electron-store` brokes migration feature

Realted issues:
#2397 
#1694 

UPD. I even found [issue in electron repo](https://github.com/electron/electron/issues/14076#issuecomment-447356527) that describes how it works - currently ERB running in not recommended "File mode" while it should run in "Package Mode" read u can read about differences in issue