### PR TITLE
remove unused dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "electron-debug": "^3.2.0",
         "electron-log": "^4.4.6",
         "electron-updater": "^4.6.5",
-        "history": "^5.3.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.3.0"
@@ -28,7 +27,6 @@
         "@types/react-test-renderer": "^17.0.1",
         "@types/terser-webpack-plugin": "^5.0.4",
         "@types/webpack-bundle-analyzer": "^4.4.1",
-        "@types/webpack-env": "^1.16.3",
         "@typescript-eslint/eslint-plugin": "^5.18.0",
         "@typescript-eslint/parser": "^5.18.0",
         "browserslist-config-erb": "^0.0.3",
@@ -67,7 +65,6 @@
         "opencollective-postinstall": "^2.0.3",
         "prettier": "^2.6.2",
         "react-refresh": "^0.12.0",
-        "react-refresh-typescript": "^2.0.4",
         "react-test-renderer": "^18.0.0",
         "rimraf": "^3.0.2",
         "sass": "^1.49.11",
@@ -2162,12 +2159,6 @@
         "tapable": "^2.2.0",
         "webpack": "^5"
       }
-    },
-    "node_modules/@types/webpack-env": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.3.tgz",
-      "integrity": "sha512-9gtOPPkfyNoEqCQgx4qJKkuNm/x0R2hKR7fdl7zvTJyHnIisuE/LfvXOsYWL0o3qq6uiBnKZNNNzi3l0y/X+xw==",
-      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -13151,16 +13142,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-refresh-typescript": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/react-refresh-typescript/-/react-refresh-typescript-2.0.4.tgz",
-      "integrity": "sha512-ySsBExEFik5Jjf7NoXtFbzUk2rYWM4gF5gg+wRTNmp9p7B2uMpAAa339FHWqmB8EAr0e6mzzskAXxc0Jd04fBw==",
-      "dev": true,
-      "peerDependencies": {
-        "react-refresh": "0.10.x || 0.11.x || 0.12.x",
-        "typescript": "^4"
-      }
-    },
     "node_modules/react-router": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.3.0.tgz",
@@ -17912,12 +17893,6 @@
         "tapable": "^2.2.0",
         "webpack": "^5"
       }
-    },
-    "@types/webpack-env": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/@types/webpack-env/-/webpack-env-1.16.3.tgz",
-      "integrity": "sha512-9gtOPPkfyNoEqCQgx4qJKkuNm/x0R2hKR7fdl7zvTJyHnIisuE/LfvXOsYWL0o3qq6uiBnKZNNNzi3l0y/X+xw==",
-      "dev": true
     },
     "@types/ws": {
       "version": "8.5.3",
@@ -26110,13 +26085,6 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.12.0.tgz",
       "integrity": "sha512-suLIhrU2IHKL5JEKR/fAwJv7bbeq4kJ+pJopf77jHwuR+HmJS/HbrPIGsTBUVfw7tXPOmYv7UJ7PCaN49e8x4A==",
       "dev": true
-    },
-    "react-refresh-typescript": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/react-refresh-typescript/-/react-refresh-typescript-2.0.4.tgz",
-      "integrity": "sha512-ySsBExEFik5Jjf7NoXtFbzUk2rYWM4gF5gg+wRTNmp9p7B2uMpAAa339FHWqmB8EAr0e6mzzskAXxc0Jd04fBw==",
-      "dev": true,
-      "requires": {}
     },
     "react-router": {
       "version": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -171,7 +171,6 @@
     "@types/react-test-renderer": "^17.0.1",
     "@types/terser-webpack-plugin": "^5.0.4",
     "@types/webpack-bundle-analyzer": "^4.4.1",
-    "@types/webpack-env": "^1.16.3",
     "@typescript-eslint/eslint-plugin": "^5.18.0",
     "@typescript-eslint/parser": "^5.18.0",
     "browserslist-config-erb": "^0.0.3",
@@ -210,7 +209,6 @@
     "opencollective-postinstall": "^2.0.3",
     "prettier": "^2.6.2",
     "react-refresh": "^0.12.0",
-    "react-refresh-typescript": "^2.0.4",
     "react-test-renderer": "^18.0.0",
     "rimraf": "^3.0.2",
     "sass": "^1.49.11",
@@ -232,7 +230,6 @@
     "electron-debug": "^3.2.0",
     "electron-log": "^4.4.6",
     "electron-updater": "^4.6.5",
-    "history": "^5.3.0",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.3.0"


### PR DESCRIPTION
Checked that all workes fine without those dependencies and found out reasons why they are not required

- `react-refresh-typescript` so [@pmmmwh/react-refresh-webpack-plugin](https://github.com/pmmmwh/react-refresh-webpack-plugin) already support typescript by default and its not require `react-refresh-typescript` only `react-refresh`

- `@types/webpack-env` - `dotenv-webpack` no need in types for it, in webpack configs used webpack 5 `EnvironmentPlugin`

- `history` - was added long ago probably as react-router dependency when it was required, now no need
