### PR TITLE
fix: Wrong img[width] units in the example app

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -6,7 +6,7 @@ const Hello = () => {
   return (
     <div>
       <div className="Hello">
-        <img width="200px" alt="icon" src={icon} />
+        <img width="200" alt="icon" src={icon} />
       </div>
       <h1>electron-react-boilerplate</h1>
       <div className="Hello">


### PR DESCRIPTION
As for the [HTML documentation](https://html.spec.whatwg.org/multipage/embedded-content-other.html#attr-dim-width), the `width` attribute of the `img` tag should only contain a non-negative integer value.

> The `width` and `height` attributes... must have values that are [valid non-negative integers](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#valid-non-negative-integer).