### PR TITLE
Refactored resolveHtmlPath

### DIFF
--- a/src/main/util.ts
+++ b/src/main/util.ts
@@ -1,18 +1,13 @@
-/* eslint import/prefer-default-export: off, import/no-mutable-exports: off */
+/* eslint import/prefer-default-export: off */
 import { URL } from 'url';
 import path from 'path';
 
-export let resolveHtmlPath: (htmlFileName: string) => string;
-
-if (process.env.NODE_ENV === 'development') {
-  const port = process.env.PORT || 1212;
-  resolveHtmlPath = (htmlFileName: string) => {
+export function resolveHtmlPath(htmlFileName: string) {
+  if (process.env.NODE_ENV === 'development') {
+    const port = process.env.PORT || 1212;
     const url = new URL(`http://localhost:${port}`);
     url.pathname = htmlFileName;
     return url.href;
-  };
-} else {
-  resolveHtmlPath = (htmlFileName: string) => {
-    return `file://${path.resolve(__dirname, '../renderer/', htmlFileName)}`;
-  };
+  }
+  return `file://${path.resolve(__dirname, '../renderer/', htmlFileName)}`;
 }


### PR DESCRIPTION
Is there any reason in returning a function based on env instead of a function that returns a path based on env?

If not I made some refactoring to it.