### PR TITLE
fix clean script

### DIFF
--- a/.erb/scripts/clean.js
+++ b/.erb/scripts/clean.js
@@ -9,7 +9,5 @@ const foldersToRemove = [
 ];
 
 foldersToRemove.forEach((folder) => {
-  if (folder !== undefined) {
-    rimraf.sync(folder);
-  }
+  rimraf.sync(folder);
 });

--- a/.erb/scripts/clean.js
+++ b/.erb/scripts/clean.js
@@ -2,16 +2,14 @@ import rimraf from 'rimraf';
 import process from 'process';
 import webpackPaths from '../configs/webpack.paths';
 
-const args = process.argv.slice(2);
-const commandMap = {
-  dist: webpackPaths.distPath,
-  release: webpackPaths.releasePath,
-  dll: webpackPaths.dllPath,
-};
+const foldersToRemove = [
+  webpackPaths.distPath,
+  webpackPaths.buildPath,
+  webpackPaths.dllPath,
+];
 
-args.forEach((x) => {
-  const pathToRemove = commandMap[x];
-  if (pathToRemove !== undefined) {
-    rimraf.sync(pathToRemove);
+foldersToRemove.forEach((folder) => {
+  if (folder !== undefined) {
+    rimraf.sync(folder);
   }
 });


### PR DESCRIPTION
clean script dont work - "clean.js" only runned in `npm run package` so its not getting any command arguments and `args` always empty

Because its only runned in `npm run package` there is no reason to leave `args` better to keep it simple