### PR TITLE
Add Playwright e2e tests

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,4 @@
+/** @type {import('eslint').Linter.Config} */
 module.exports = {
   extends: 'erb',
   rules: {
@@ -27,4 +28,13 @@ module.exports = {
       '@typescript-eslint/parser': ['.ts', '.tsx'],
     },
   },
+  overrides: [
+    {
+      files: ['**/e2e/**/*'],
+      rules: {
+        'jest/no-standalone-expect': 'off',
+      },
+      plugins: ['playwright'],
+    },
+  ],
 };

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,8 +21,7 @@ jobs:
           cache: npm
 
       - name: npm install
-        run: |
-          npm install
+        run: npm ci
 
       - name: npm test
         env:
@@ -32,3 +31,13 @@ jobs:
           npm run lint
           npm exec tsc
           npm test
+
+      - name: Run Playwright tests
+        run: npx playwright test
+
+      - uses: actions/upload-artifact@v2
+        if: always()
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ npm-debug.log.*
 *.css.d.ts
 *.sass.d.ts
 *.scss.d.ts
+/test-results/
+/playwright-report/
+/playwright/.cache/

--- a/e2e/example.spec.ts
+++ b/e2e/example.spec.ts
@@ -1,0 +1,48 @@
+import {
+  test,
+  expect,
+  _electron as electron,
+  Page,
+  ElectronApplication,
+} from '@playwright/test';
+import path from 'path';
+
+/**
+ * For Getting started with Playwright, see here:
+ * @see https://playwright.dev/docs/intro
+ */
+
+test.describe.serial(() => {
+  let page: Page;
+  let electronApp: ElectronApplication;
+  test.beforeAll(async () => {
+    electronApp = await electron.launch({
+      args: [
+        path.join(__dirname, '..', 'release', 'app', 'dist', 'main', 'main.js'),
+      ],
+    });
+    page = await electronApp.firstWindow();
+    // Direct Electron console to Node terminal.
+    page.on('console', console.log);
+  });
+  test.afterAll(async () => {
+    await electronApp.close();
+  });
+  test('Electron App has the correct buttons on it', async () => {
+    // Evaluation expression in the Electron context.
+    const appPath = await electronApp.evaluate(async ({ app }) => {
+      // This runs in the main Electron process, parameter here is always
+      // the result of the require('electron') in the main app script.
+      return app.getAppPath();
+    });
+    console.log(appPath);
+
+    // Print the title.
+    console.log(await page.title());
+
+    await expect(page).toHaveTitle('Hello Electron React!');
+    await expect(page.locator('text=📚Read our docs')).toBeVisible();
+    await expect(page.locator('text=🙏Donate')).toBeVisible();
+    await expect(page.locator('text=electron-react-boilerplate')).toBeVisible();
+  });
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "npm-proj-1657097908310-0.9041824655096293IMUlOL",
+  "name": "electron-react-boilerplate",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
@@ -15,6 +15,7 @@
         "react-router-dom": "^6.3.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.24.2",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.6",
         "@teamsupercell/typings-for-css-modules-loader": "^2.5.1",
         "@testing-library/jest-dom": "^5.16.4",
@@ -51,6 +52,7 @@
         "eslint-plugin-import": "^2.26.0",
         "eslint-plugin-jest": "^26.2.2",
         "eslint-plugin-jsx-a11y": "^6.5.1",
+        "eslint-plugin-playwright": "^0.10.0",
         "eslint-plugin-promise": "^6.0.0",
         "eslint-plugin-react": "^7.29.4",
         "eslint-plugin-react-hooks": "^4.5.0",
@@ -1529,6 +1531,22 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.24.2.tgz",
+      "integrity": "sha512-Q4X224pRHw4Dtkk5PoNJplZCokLNvVbXD9wDQEMrHcEuvWpJWEQDeJ9gEwkZ3iCWSFSWBshIX177B231XW4wOQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*",
+        "playwright-core": "1.24.2"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -7443,6 +7461,21 @@
         "node": ">=6.0"
       }
     },
+    "node_modules/eslint-plugin-playwright": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.10.0.tgz",
+      "integrity": "sha512-67iCGx4UZS8Z/Z9CcNbWjoJ7v5t7awfV2REm6hjEywYhE36GsOwGzgvDJ+dYdNwC1enLxFijUvwzfnIUin+5DA==",
+      "dev": true,
+      "peerDependencies": {
+        "eslint": ">=7",
+        "eslint-plugin-jest": ">=24"
+      },
+      "peerDependenciesMeta": {
+        "eslint-plugin-jest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/eslint-plugin-prettier": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
@@ -12756,6 +12789,18 @@
         "node": ">=8"
       }
     },
+    "node_modules/playwright-core": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.24.2.tgz",
+      "integrity": "sha512-zfAoDoPY/0sDLsgSgLZwWmSCevIg1ym7CppBwllguVBNiHeixZkc1AdMuYUPZC6AdEYc4CxWEyLMBTw2YcmRrA==",
+      "dev": true,
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/plist": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/plist/-/plist-3.0.5.tgz",
@@ -17848,6 +17893,16 @@
         }
       }
     },
+    "@playwright/test": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.24.2.tgz",
+      "integrity": "sha512-Q4X224pRHw4Dtkk5PoNJplZCokLNvVbXD9wDQEMrHcEuvWpJWEQDeJ9gEwkZ3iCWSFSWBshIX177B231XW4wOQ==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "playwright-core": "1.24.2"
+      }
+    },
     "@pmmmwh/react-refresh-webpack-plugin": {
       "version": "0.5.6",
       "resolved": "https://registry.npmjs.org/@pmmmwh/react-refresh-webpack-plugin/-/react-refresh-webpack-plugin-0.5.6.tgz",
@@ -22428,6 +22483,13 @@
         }
       }
     },
+    "eslint-plugin-playwright": {
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-playwright/-/eslint-plugin-playwright-0.10.0.tgz",
+      "integrity": "sha512-67iCGx4UZS8Z/Z9CcNbWjoJ7v5t7awfV2REm6hjEywYhE36GsOwGzgvDJ+dYdNwC1enLxFijUvwzfnIUin+5DA==",
+      "dev": true,
+      "requires": {}
+    },
     "eslint-plugin-prettier": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.4.1.tgz",
@@ -26398,6 +26460,12 @@
           }
         }
       }
+    },
+    "playwright-core": {
+      "version": "1.24.2",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.24.2.tgz",
+      "integrity": "sha512-zfAoDoPY/0sDLsgSgLZwWmSCevIg1ym7CppBwllguVBNiHeixZkc1AdMuYUPZC6AdEYc4CxWEyLMBTw2YcmRrA==",
+      "dev": true
     },
     "plist": {
       "version": "3.0.5",

--- a/package.json
+++ b/package.json
@@ -116,6 +116,7 @@
     "react-router-dom": "^6.3.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.24.2",
     "@pmmmwh/react-refresh-webpack-plugin": "^0.5.6",
     "@teamsupercell/typings-for-css-modules-loader": "^2.5.1",
     "@testing-library/jest-dom": "^5.16.4",
@@ -152,6 +153,7 @@
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^26.2.2",
     "eslint-plugin-jsx-a11y": "^6.5.1",
+    "eslint-plugin-playwright": "^0.10.0",
     "eslint-plugin-promise": "^6.0.0",
     "eslint-plugin-react": "^7.29.4",
     "eslint-plugin-react-hooks": "^4.5.0",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,42 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+
+/**
+ * Read environment variables from file.
+ * https://github.com/motdotla/dotenv
+ */
+// require('dotenv').config();
+
+/**
+ * See https://playwright.dev/docs/test-configuration.
+ */
+const config: PlaywrightTestConfig = {
+  testDir: './e2e',
+  /* Maximum time one test can run for. */
+  timeout: 30 * 1000,
+  expect: {
+    /**
+     * Maximum time expect() should wait for the condition to be met.
+     * For example in `await expect(locator).toHaveText();`
+     */
+    timeout: 5000,
+  },
+  /* Run tests in files in parallel */
+  fullyParallel: true,
+  /* Fail the build on CI if you accidentally left test.only in the source code. */
+  forbidOnly: !!process.env.CI,
+  /* Retry on CI only */
+  retries: process.env.CI ? 2 : 0,
+  /* Opt out of parallel tests on CI. */
+  workers: process.env.CI ? 1 : undefined,
+  /* Reporter to use. See https://playwright.dev/docs/test-reporters */
+  reporter: 'html',
+  /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
+  use: {
+    /* Maximum time each action such as `click()` can take. Defaults to 0 (no limit). */
+    actionTimeout: 0,
+    /* Base URL to use in actions like `await page.goto('/')`. */
+    // baseURL: 'http://localhost:3000',
+  },
+};
+
+export default config;


### PR DESCRIPTION
Since we at Playwright got many requests in the past about electron-react-boilerplate and how to use it with Playwright, I thought it might make sense to add it to the project directly.

This runs the tests on the compiled JS with the installed Electron version, like "npx playwright main.js" would do.

