### PR TITLE
Skip building DLLs when required from eslint config

### DIFF
--- a/.erb/configs/webpack.config.renderer.dev.ts
+++ b/.erb/configs/webpack.config.renderer.dev.ts
@@ -20,8 +20,8 @@ if (process.env.NODE_ENV === 'production') {
 const port = process.env.PORT || 1212;
 const manifest = path.resolve(webpackPaths.dllPath, 'renderer.json');
 const skipDLLs =
-  module.parent?.filename.includes("webpack.config.renderer.dev.dll") ||
-  module.parent?.filename.includes("webpack.config.eslint")
+  module.parent?.filename.includes('webpack.config.renderer.dev.dll') ||
+  module.parent?.filename.includes('webpack.config.eslint');
 
 /**
  * Warn if the DLL is not built

--- a/.erb/configs/webpack.config.renderer.dev.ts
+++ b/.erb/configs/webpack.config.renderer.dev.ts
@@ -19,16 +19,15 @@ if (process.env.NODE_ENV === 'production') {
 
 const port = process.env.PORT || 1212;
 const manifest = path.resolve(webpackPaths.dllPath, 'renderer.json');
-// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-const requiredByDLLConfig = module.parent!.filename.includes(
-  'webpack.config.renderer.dev.dll'
-);
+const skipDLLs =
+  module.parent?.filename.includes("webpack.config.renderer.dev.dll") ||
+  module.parent?.filename.includes("webpack.config.eslint")
 
 /**
  * Warn if the DLL is not built
  */
 if (
-  !requiredByDLLConfig &&
+  !skipDLLs &&
   !(fs.existsSync(webpackPaths.dllPath) && fs.existsSync(manifest))
 ) {
   console.log(
@@ -97,7 +96,7 @@ const configuration: webpack.Configuration = {
     ],
   },
   plugins: [
-    ...(requiredByDLLConfig
+    ...(skipDLLs
       ? []
       : [
           new webpack.DllReferencePlugin({


### PR DESCRIPTION
I noticed that DLLs were being built during the lint script and making things take longer. It's probably not a big deal usually, but when running scripts in CI the dll files don't exist before running eslint and from what I can tell they don't need to be. Figured this might be useful to put up for consideration.

closes https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/3290