### PR TITLE
Fix preload returning ipcRenderer

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -12,7 +12,9 @@ contextBridge.exposeInMainWorld('electron', {
         func(...args);
       ipcRenderer.on(channel, subscription);
 
-      return () => ipcRenderer.removeListener(channel, subscription);
+      return () => {
+        ipcRenderer.removeListener(channel, subscription);
+      };
     },
     once(channel: Channels, func: (...args: unknown[]) => void) {
       ipcRenderer.once(channel, (_event, ...args) => func(...args));

--- a/src/renderer/preload.d.ts
+++ b/src/renderer/preload.d.ts
@@ -6,10 +6,10 @@ declare global {
       ipcRenderer: {
         sendMessage(channel: Channels, args: unknown[]): void;
         on(
-          channel: string,
+          channel: Channels,
           func: (...args: unknown[]) => void
         ): (() => void) | undefined;
-        once(channel: string, func: (...args: unknown[]) => void): void;
+        once(channel: Channels, func: (...args: unknown[]) => void): void;
       };
     };
   }


### PR DESCRIPTION
Fix preload returning ipcRenderer. [Electron's Context Isolation article](https://www.electronjs.org/docs/latest/tutorial/context-isolation#security-considerations) explains that exposing ipcRenderer is unsafe.
## Changes
- [Security fix] Made `preload.ts`'s `electron.ipcRenderer.on` function stop returning the `IpcRenderer` so that the renderer process cannot freely access the preloader's `ipcRenderer` object.
- Fixed `preload.d.ts`'s type declarations inconsistently using `string` instead of `Channels` as the parameters are defined in `preload.ts`

[Electron's Context Isolation article](https://www.electronjs.org/docs/latest/tutorial/context-isolation#security-considerations) also considers exposing `IpcRenderer.send` to be unsafe. Please consider adding a check to prevent sending messages with channels other than the ones defined in `preload.ts`. Consider creating an array of whitelisted channels `as const` and creating the `Channels` type from that like in [this StackOverflow post](https://stackoverflow.com/a/59857409). I can probably find time to add Typescript-aware channel whitelisting to this pull request if you'd like as I implemented it in another repository, but I did not want to request significant changes to the official boilerplate without knowing if this would be appropriate.

## Significance

Without the changes in this pull request, the renderer process is able to use `preload.ts`'s `ipcRenderer` object freely by using the return of the `electron.ipcRenderer.on` function from `preload.ts`.

Adding the following code in `src/renderer/index.tsx`:
![image](https://user-images.githubusercontent.com/3528918/189001488-84af82b9-76c9-4a02-9162-1fde030a353e.png)

Results in the following output in the main process (bottom in dark colors) and renderer process (right side in light colors):
![image](https://user-images.githubusercontent.com/3528918/189001599-24bf9e14-2640-4ad7-b05e-cfb372945934.png)

The renderer process in `index.tsx` is able to use any `IpcRenderer` method like `IpcRenderer.send` on `theRealIpcRenderer`, which is not available on `window.electron.ipcRenderer`. As such, we see the message `'improper access in renderer process'` sent from `index.tsx` appear in the main process console, bypassing `preloader.ts`'s `electron.ipcRenderer`.
