### PR TITLE
More resilient publish workflow options

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,5 +46,15 @@ jobs:
 
           # This is used for uploading release assets to github - GH provides it by default
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
         run: |
-          npm exec electron-builder -- --publish always --win --mac --linux
+          if [ "$RUNNER_OS" == "Linux" ]; then
+            npm exec electron-builder -- --publish always --linux
+          elif [ "$RUNNER_OS" == "Windows" ]; then
+            npm exec electron-builder -- --publish always --win
+          elif [ "$RUNNER_OS" == "macOS" ]; then
+            npm exec electron-builder -- --publish always --mac
+          else
+            echo "$RUNNER_OS not supported"
+            exit 1
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -35,12 +35,16 @@ jobs:
 
       - name: Publish releases
         env:
-          # These values are used for auto updates signing
-          APPLE_ID: ${{ secrets.APPLE_ID }}
-          APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS }}
-          CSC_LINK: ${{ secrets.CSC_LINK }}
-          CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
-          # This is used for uploading release assets to github
+          # These values are used to sign code for smoother installation and auto updates.
+          # Enabling them with wrong or unconfigured values will break your build
+          # see https://www.electron.build/code-signing.html
+          #
+          # APPLE_ID: ${{ secrets.APPLE_ID }}
+          # APPLE_ID_PASS: ${{ secrets.APPLE_ID_PASS }}
+          # CSC_LINK: ${{ secrets.CSC_LINK }}
+          # CSC_KEY_PASSWORD: ${{ secrets.CSC_KEY_PASSWORD }}
+
+          # This is used for uploading release assets to github - GH provides it by default
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm exec electron-builder -- --publish always --win --mac --linux


### PR DESCRIPTION
This solves two challenges I faced when upgrading the publish workflow:

1. Without the signing environment vars setup in GH, the build breaks
   * I didn't test this, but I imagine defining them with incorrect values is also unhelpful
2. Building a "msi", "rpm", or "deb" under only MacOs caused build problems. Running each build on the native OS has so far allowed those to work. 

This setup (with some other stuff) is running/working over [here](https://github.com/jessedp/tablo-tools-electron/blob/main/.github/workflows/publish.ymll).