### PR TITLE
fix: allow absolute renderer imports in Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,7 +80,8 @@
   "jest": {
     "moduleDirectories": [
       "node_modules",
-      "release/app/node_modules"
+      "release/app/node_modules",
+      "src"
     ],
     "moduleFileExtensions": [
       "js",


### PR DESCRIPTION
Fixes  #3326

Add `src` to the `moduleDirectories` Jest option in the root `package.json`, so it's possible to `import hello from 'renderer/hello'` from test files.