### PR TITLE
fix: add ports for build analyzer

### DIFF
--- a/.erb/configs/webpack.config.main.prod.ts
+++ b/.erb/configs/webpack.config.main.prod.ts
@@ -46,6 +46,7 @@ const configuration: webpack.Configuration = {
   plugins: [
     new BundleAnalyzerPlugin({
       analyzerMode: process.env.ANALYZE === 'true' ? 'server' : 'disabled',
+      analyzerPort: 8888,
     }),
 
     /**

--- a/.erb/configs/webpack.config.renderer.prod.ts
+++ b/.erb/configs/webpack.config.renderer.prod.ts
@@ -122,6 +122,7 @@ const configuration: webpack.Configuration = {
 
     new BundleAnalyzerPlugin({
       analyzerMode: process.env.ANALYZE === 'true' ? 'server' : 'disabled',
+      analyzerPort: 8889,
     }),
 
     new HtmlWebpackPlugin({


### PR DESCRIPTION
Fixed issue with a used port by the first analyzer when using `ANALYZE=true npm run build`

![CleanShot 2022-11-08 at 15 06 05](https://user-images.githubusercontent.com/9741188/200586456-4d10b9bd-a72f-4f4a-b174-516a3c7a6c29.png)

For clarity, I set both ports (also the default one `8888`).