### PR TITLE
Fix location of `preload.js` for playwright tests

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -75,9 +75,10 @@ const createWindow = async () => {
     height: 728,
     icon: getAssetPath('icon.png'),
     webPreferences: {
-      preload: app.isPackaged
-        ? path.join(__dirname, 'preload.js')
-        : path.join(__dirname, '../../.erb/dll/preload.js'),
+      preload:
+        process.env.NODE_ENV === 'development'
+          ? path.join(__dirname, '../../.erb/dll/preload.js')
+          : path.join(__dirname, 'preload.js'),
     },
   });
 


### PR DESCRIPTION
Without this change, the Playwright guide is not working: https://electron-react-boilerplate.js.org/docs/integration-tests

Thanks for your work!