### PR TITLE
fix: set main process.type to "browser" in production

### DIFF
--- a/.erb/configs/webpack.config.main.prod.ts
+++ b/.erb/configs/webpack.config.main.prod.ts
@@ -65,7 +65,7 @@ const configuration: webpack.Configuration = {
     }),
 
     new webpack.DefinePlugin({
-      'process.type': '"main"',
+      'process.type': '"browser"',
     }),
   ],
 


### PR DESCRIPTION
According to the [documentation](https://www.electronjs.org/docs/latest/api/process#processtype-readonly), the only valid values for `process.type` are:

*  `browser`: The main process.
*  `renderer`: A renderer process.
*  `worker`: In a web worker.
* `utility`: In  a node process launched as a service.

Currently, running the application with `yarn start` the `process.type` value in the main process is `browser`, but in a packaged app it is `main`, so this PR fixes it to be `browser` too.

Consequently, the warning from `electron-devtools-installer` while trying to install `REACT_DEVELOPER_TOOLS` in a production-debug environment is gone.

Fix #3391 