### PR TITLE
add .erb/dll to jest ignore

### DIFF
--- a/package.json
+++ b/package.json
@@ -102,7 +102,8 @@
       "url": "http://localhost/"
     },
     "testPathIgnorePatterns": [
-      "release/app/dist"
+      "release/app/dist",
+      ".erb/dll"
     ],
     "transform": {
       "\\.(ts|tsx|js|jsx)$": "ts-jest"


### PR DESCRIPTION
Add ignore rule for .erb/dll so that jest doesn't execute all tests twice.