### PR TITLE
fix: fix ipcRenderer.sendMessage incorrect defintion

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -6,8 +6,8 @@ export type Channels = 'ipc-example';
 
 const electronHandler = {
   ipcRenderer: {
-    sendMessage(channel: Channels, args: unknown[]) {
-      ipcRenderer.send(channel, args);
+    sendMessage(channel: Channels, ...args: unknown[]) {
+      ipcRenderer.send(channel, ...args);
     },
     on(channel: Channels, func: (...args: unknown[]) => void) {
       const subscription = (_event: IpcRendererEvent, ...args: unknown[]) =>


### PR DESCRIPTION
In electron origin definition with `send` should be allow accept multi args