### PR TITLE
fix: swapped logic for symlink check

### DIFF
--- a/.erb/scripts/link-modules.ts
+++ b/.erb/scripts/link-modules.ts
@@ -4,6 +4,6 @@ import webpackPaths from '../configs/webpack.paths';
 const { srcNodeModulesPath } = webpackPaths;
 const { appNodeModulesPath } = webpackPaths;
 
-if (!fs.existsSync(srcNodeModulesPath) && fs.existsSync(appNodeModulesPath)) {
+if (fs.existsSync(srcNodeModulesPath) && !fs.existsSync(appNodeModulesPath)) {
   fs.symlinkSync(appNodeModulesPath, srcNodeModulesPath, 'junction');
 }


### PR DESCRIPTION
I kept receiving :

```
EEXIST: file already exists, symlink '/home/[redacted]/release/app/node_modules' -> '/home/[redacted]/src/node_modules'
```

Surely this was wrong - we want to create the symlink if the source exists and the target does not, not the other way round.