### PR TITLE
fix: added glob option to rimraf.sync call

### DIFF
--- a/.erb/scripts/delete-source-maps.js
+++ b/.erb/scripts/delete-source-maps.js
@@ -5,7 +5,11 @@ import webpackPaths from '../configs/webpack.paths';
 
 export default function deleteSourceMaps() {
   if (fs.existsSync(webpackPaths.distMainPath))
-    rimraf.sync(path.join(webpackPaths.distMainPath, '*.js.map'));
+    rimraf.sync(path.join(webpackPaths.distMainPath, '*.js.map'), {
+      glob: true,
+    });
   if (fs.existsSync(webpackPaths.distRendererPath))
-    rimraf.sync(path.join(webpackPaths.distRendererPath, '*.js.map'));
+    rimraf.sync(path.join(webpackPaths.distRendererPath, '*.js.map'), {
+      glob: true,
+    });
 }


### PR DESCRIPTION
Rimraf removed the option to treat file paths as glob patterns, which caused npm run build failing when running the second time.
By adding the option to the rimraf.sync calls, we enable back the behavior we need.