### PR TITLE
fix: custom enum with eslint errors

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,6 @@
 module.exports = {
   extends: 'erb',
+  plugins: ['@typescript-eslint'],
   rules: {
     // A temporary hack related to IDE not resolving correct package.json
     'import/no-extraneous-dependencies': 'off',
@@ -8,6 +9,10 @@ module.exports = {
     'import/extensions': 'off',
     'import/no-unresolved': 'off',
     'import/no-import-module-exports': 'off',
+    'no-shadow': 'off',
+    '@typescript-eslint/no-shadow': 'error',
+    'no-unused-vars': 'off',
+    '@typescript-eslint/no-unused-vars': 'error',
   },
   parserOptions: {
     ecmaVersion: 2020,


### PR DESCRIPTION
Related issue: https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/3468

The root cause is that eslint's rules: `no-shadow` and `no-unused-vars` can't work well with enum in typescript, so replace them with `@typescript-eslint` rules.