### PR TITLE
fix notarization: use APPLE_APP_SPECIFIC_PASSWORD instead of APPLE_ID_PASS

### DIFF
--- a/.erb/scripts/notarize.js
+++ b/.erb/scripts/notarize.js
@@ -12,9 +12,9 @@ exports.default = async function notarizeMacos(context) {
     return;
   }
 
-  if (!('APPLE_ID' in process.env && 'APPLE_ID_PASS' in process.env)) {
+  if (!('APPLE_ID' in process.env && 'APPLE_APP_SPECIFIC_PASSWORD' in process.env)) {
     console.warn(
-      'Skipping notarizing step. APPLE_ID and APPLE_ID_PASS env variables must be set'
+      'Skipping notarizing step. APPLE_ID and APPLE_APP_SPECIFIC_PASSWORD env variables must be set'
     );
     return;
   }
@@ -25,6 +25,6 @@ exports.default = async function notarizeMacos(context) {
     appBundleId: build.appId,
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLE_ID,
-    appleIdPassword: process.env.APPLE_ID_PASS,
+    appleIdPassword: process.env.APPLE_APP_SPECIFIC_PASSWORD,
   });
 };


### PR DESCRIPTION
According to the [documentation in electron/notarize](https://github.com/electron/notarize/blob/295c39d8c0ec21efa282161c667576fc7cb39558/README.md?plain=1#L44-L62)

the `appleIdPassword` should be the app-specific-password, and **not** the password of the developer account. 

And, the [electron-builder documentation for macOS signing](https://www.electron.build/configuration/mac) mentions setting the `APPLE_APP_SPECIFIC_PASSWORD` to that value.

<img width="968" alt="Screenshot 2023-06-14 at 11 25 31 PM" src="https://github.com/electron-react-boilerplate/electron-react-boilerplate/assets/57226514/ffc61404-7eaf-4ada-bce8-804459654b0c">


**Seeing as this project relies on both these tools, it would be more appropriate to use `APPLE_APP_SPECIFIC_PASSWORD` environment variable rather than `APPLE_ID_PASS` (_which is currently used_)**


