### PR TITLE
feat notarization: use notarytool for code-signing

### DIFF
--- a/.erb/scripts/notarize.js
+++ b/.erb/scripts/notarize.js
@@ -22,9 +22,11 @@ exports.default = async function notarizeMacos(context) {
   const appName = context.packager.appInfo.productFilename;
 
   await notarize({
+    tool: "notarytool",
     appBundleId: build.appId,
     appPath: `${appOutDir}/${appName}.app`,
     appleId: process.env.APPLE_ID,
     appleIdPassword: process.env.APPLE_ID_PASS,
+    teamId: process.env.APPLE_TEAM_ID
   });
 };

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     ],
     "afterSign": ".erb/scripts/notarize.js",
     "mac": {
+      "notarize" : false,
       "target": {
         "target": "default",
         "arch": [


### PR DESCRIPTION
The default alt-tool has been deprecated for more than a year and will soon become unsupported 

Here's the [issue tracking the change in electron notarize](https://github.com/electron/notarize/issues/137)
And based on the [changes being made to support this](https://github.com/electron/notarize/pull/141) it will be a breaking change, that will later use `notarytool` as the default (which is also recommended by apple documentation)

This PR adds changes to now use the `notarytool` for code-signing. But this also **requires the environment to have an extra `APPLE_TEAM_ID`** variable to be set. This is the team ID you want to notarize under.

