### PR TITLE
fix: restart by edit code, but error code: 3221226525

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -124,6 +124,14 @@ app.on('window-all-closed', () => {
   }
 });
 
+app.on('before-quit', () => {
+  // fix: restart by edit code, but error: [electronmon] app exited with code 3221226525, waiting for change to restart it
+  for (const window of BrowserWindow.getAllWindows()) {
+    window.webContents.closeDevTools()
+    window.close();
+  }
+});
+
 app
   .whenReady()
   .then(() => {


### PR DESCRIPTION
Fixed an error when app.quit is triggered by modifying the code under main when a sub-window is opened: app exited with code 3221226525