### PR TITLE
fix(security): remove unnecessary mac entitlements permission allow-u…

### DIFF
--- a/assets/entitlements.mac.plist
+++ b/assets/entitlements.mac.plist
@@ -2,8 +2,6 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
   <dict>
-    <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
-    <true/>
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
   </dict>


### PR DESCRIPTION
removes unnecessary mac entitlements permission allow-unsigned-executable-memory

not needed since electron 11

source: https://github.com/electron/notarize

<img width="717" alt="Captura de pantalla 2023-09-25 a la(s) 11 02 25 a m" src="https://github.com/electron-react-boilerplate/electron-react-boilerplate/assets/3721291/ce42c14a-3160-40e1-b35f-6cd660d58348">