### PR TITLE
package command update. from "electron-builder build" to "electron-builder -mwl"

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "build:renderer": "cross-env NODE_ENV=production TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.renderer.prod.ts",
     "postinstall": "ts-node .erb/scripts/check-native-dep.js && electron-builder install-app-deps && npm run build:dll",
     "lint": "cross-env NODE_ENV=development eslint . --ext .js,.jsx,.ts,.tsx",
-    "package": "ts-node ./.erb/scripts/clean.js dist && npm run build && electron-builder build --publish never && npm run build:dll",
+    "package": "ts-node ./.erb/scripts/clean.js dist && npm run build && electron-builder -mwl --publish never && npm run build:dll",
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
     "start": "ts-node ./.erb/scripts/check-port-in-use.js && npm run start:renderer",
     "start:main": "cross-env NODE_ENV=development electronmon -r ts-node/register/transpile-only .",


### PR DESCRIPTION
HI there, I wanted to contribute by updating the package command as I recently needed to make a project and package and it took me almost 2 days to make builds. it kept giving me workspace errors. then I got to know that electron-builder changed the build command to electron-builder -mwl.

So here's my code. 