### PR TITLE
Update "preload.js" to "preload.ts" in main.ts

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -76,7 +76,7 @@ const createWindow = async () => {
     icon: getAssetPath('icon.png'),
     webPreferences: {
       preload: app.isPackaged
-        ? path.join(__dirname, 'preload.js')
+        ? path.join(__dirname, 'preload.ts')
         : path.join(__dirname, '../../.erb/dll/preload.js'),
     },
   });


### PR DESCRIPTION
Upon cloning the project and running, the preload script located at `/src/main/preload.ts` does not get executed due to a typo in this section of main.ts, which is responsible for specifying the path of the file to preload. It should be `preload.ts`, not `preload.js`.