### PR TITLE
Removed "@types/terser-webpack-plugin"

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,6 @@
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
     "@types/react-test-renderer": "^18.0.1",
-    "@types/terser-webpack-plugin": "^5.0.4",
     "@types/webpack-bundle-analyzer": "^4.6.0",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",


### PR DESCRIPTION
Types for the terser-webpack-plugin are no longer needed because they are built-in.