### PR TITLE
Fix MAIN_ARGS not properly getting passed into main.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
     "prestart": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.main.dev.ts",
     "start": "ts-node ./.erb/scripts/check-port-in-use.js && npm run prestart && npm run start:renderer",
-    "start:main": "concurrently -k \"cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --watch --config ./.erb/configs/webpack.config.main.dev.ts\" \"electronmon .\"",
+    "start:main": "concurrently -k -P \"cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --watch --config ./.erb/configs/webpack.config.main.dev.ts\" \"electronmon . {@}\" --",
     "start:preload": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.preload.dev.ts",
     "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",
     "test": "jest"


### PR DESCRIPTION
[Recent changes to the `start:main` script to support Electron 28+](https://github.com/electron-react-boilerplate/electron-react-boilerplate/pull/3633/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519) seem to have accidentally broke the code in `.erb/configs/webpack.config.renderer.dev.ts` that transforms the environment variable `MAIN_ARGS` to arguments passed into `electronmon` to support passing command-line arguments into `main.ts`. This PR fixes `MAIN_ARGS` to properly pass down to `main.ts` again.

See [`concurrently` docs](https://github.com/open-cli-tools/concurrently/blob/main/docs/cli/passthrough-arguments.md) for an explanation of `-P` and `{@}`.

Note: the `--` at the end of the command is there to indicate to `concurrently` that the arguments passed to it are to be passed down. It is not a duplicate of the `--` passed in from `.erb/configs/webpack.config.renderer.dev.ts` because that escapes the command line arguments when running `npm run start:main` itself, not `concurrently`. As strange as it looks, both are required.