### PR TITLE
issue: source-map-support not working in developer mode

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -31,16 +31,13 @@ ipcMain.on('ipc-example', async (event, arg) => {
   event.reply('ipc-example', msgTemplate('pong'));
 });
 
-if (process.env.NODE_ENV === 'production') {
-  const sourceMapSupport = require('source-map-support');
-  sourceMapSupport.install();
-}
-
 const isDebug =
   process.env.NODE_ENV === 'development' || process.env.DEBUG_PROD === 'true';
 
 if (isDebug) {
   require('electron-debug')();
+  const sourceMapSupport = require('source-map-support');
+  sourceMapSupport.install();
 }
 
 const installExtensions = async () => {


### PR DESCRIPTION
errors not pointing the source code that causes

source-map-support was working in production mode, whereas it should work in developer mode.