### PR TITLE
fix: allow compilation with npm 10.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -243,8 +243,16 @@
     "url": "https://opencollective.com/electron-react-boilerplate-594"
   },
   "devEngines": {
-    "node": ">=14.x",
-    "npm": ">=7.x"
+    "runtime": {
+      "name": "node",
+      "version": ">=14.x",
+      "onFail": "error"
+    },
+    "packageManager": {
+      "name": "npm",
+      "version": ">=7.x",
+      "onFail": "error"
+    }
   },
   "electronmon": {
     "patterns": [


### PR DESCRIPTION
Fix #3648

I implemented this comment:
https://github.com/electron-react-boilerplate/electron-react-boilerplate/issues/3648#issuecomment-2490151716 and now `npm install` runs without error