### PR TITLE
Add ELECTRON_SANDBOX param to pass --no-sandbox to electronmon

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
     "prestart": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.main.dev.ts",
     "start": "ts-node ./.erb/scripts/check-port-in-use.js && npm run prestart && npm run start:renderer",
-    "start:main": "concurrently -k \"cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --watch --config ./.erb/configs/webpack.config.main.dev.ts\" \"electronmon .\"",
+    "start:main": "concurrently -k \"cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --watch --config ./.erb/configs/webpack.config.main.dev.ts\" \"electronmon $ELECTRON_SANDBOX .\"",
     "start:preload": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --config ./.erb/configs/webpack.config.preload.dev.ts",
     "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",
     "test": "jest"


### PR DESCRIPTION
On Ubuntu >24.04 and derivatives there's known problem with sandboxing electron apps. This is related to apparmor profile. To avoid this "--no-sandbox" is needed to run the dev/builded app. With that change you can do:
ELECTRON_SANDBOX=--no-sandbox npm start
which will start devel on ubuntu.

This of course raise some security problems but personally I don't know any other solution.

https://github.com/electron/electron/issues/18265
https://github.com/electron/electron/issues/41066