### PR TITLE
bugfix: native module resolution is broken

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
       "url": "https://github.com/amilajack"
     }
   ],
-  "main": "./.erb/dll/main.bundle.dev.js",
   "scripts": {
     "build": "concurrently \"npm run build:main\" \"npm run build:renderer\"",
     "build:dll": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true NODE_OPTIONS=\"-r ts-node/register --no-warnings\" webpack --config ./.erb/configs/webpack.config.renderer.dev.dll.ts",
@@ -46,7 +45,7 @@
     "rebuild": "electron-rebuild --parallel --types prod,dev,optional --module-dir release/app",
     "prestart": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true NODE_OPTIONS=\"-r ts-node/register --no-warnings\" webpack --config ./.erb/configs/webpack.config.main.dev.ts",
     "start": "ts-node ./.erb/scripts/check-port-in-use.js && npm run prestart && npm run start:renderer",
-    "start:main": "concurrently -k -P \"cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --watch --config ./.erb/configs/webpack.config.main.dev.ts\" \"electronmon . -- {@}\" --",
+    "start:main": "concurrently -k -P \"cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true webpack --watch --config ./.erb/configs/webpack.config.main.dev.ts\" \"electronmon ./.erb/dll/main.bundle.dev.js -- {@}\" --",
     "start:preload": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true NODE_OPTIONS=\"-r ts-node/register --no-warnings\" webpack --config ./.erb/configs/webpack.config.preload.dev.ts",
     "start:renderer": "cross-env NODE_ENV=development TS_NODE_TRANSPILE_ONLY=true NODE_OPTIONS=\"-r ts-node/register --no-warnings\" webpack serve --config ./.erb/configs/webpack.config.renderer.dev.ts",
     "test": "jest"


### PR DESCRIPTION
Even though the official 'package.json' docs regarding "main" property make it seems like the recently introduced 'electronmon .' approach could work, it turns out that's not the case.

When going via 'main' property, regardless of the specified path, the actual "nodejs module resolution" will start at the '<repo>/node_modules/' level and then bubble upwards. As a result the symlinked folders '<repo>/src/node_modules' and '<repo/.erb/node_modules/' will not be considered, hence native module resolution breaks.

The solution is simply to specify the 'main.bundle.dev.js' file directly in regards to the 'electronmon' call.

Furthermore the 'main' property was removed altogether now, cause it seemingly serves no practical purpose in this template and at best is misleading if it were to stay around.