### PR TITLE
Improve external dependency compatibility: native module detection and DLL exclusion option

### DIFF
--- a/.erb/configs/webpack.config.renderer.dev.dll.ts
+++ b/.erb/configs/webpack.config.renderer.dev.dll.ts
@@ -14,6 +14,8 @@ checkNodeEnv('development');
 
 const dist = webpackPaths.dllPath;
 
+const dllExclude: string[] = [];
+
 const configuration: webpack.Configuration = {
   context: webpackPaths.rootPath,
 
@@ -31,7 +33,9 @@ const configuration: webpack.Configuration = {
   module: require('./webpack.config.renderer.dev').default.module,
 
   entry: {
-    renderer: Object.keys(dependencies || {}),
+    renderer: Object.keys(dependencies || {}).filter(
+      (dep) => !dllExclude.includes(dep)
+    ),
   },
 
   output: {

--- a/.erb/scripts/check-native-dep.js
+++ b/.erb/scripts/check-native-dep.js
@@ -8,29 +8,20 @@ if (dependencies) {
   const nativeDeps = fs
     .readdirSync('node_modules')
     .filter((folder) => fs.existsSync(`node_modules/${folder}/binding.gyp`));
-  if (nativeDeps.length === 0) {
+  const filteredRootDependencies = nativeDeps.filter((dep) =>
+    dependenciesKeys.includes(dep),
+  );
+  if (filteredRootDependencies.length === 0) {
     process.exit(0);
   }
-  try {
-    // Find the reason for why the dependency is installed. If it is installed
-    // because of a devDependency then that is okay. Warn when it is installed
-    // because of a dependency
-    const { dependencies: dependenciesObject } = JSON.parse(
-      execSync(`npm ls ${nativeDeps.join(' ')} --json`).toString(),
-    );
-    const rootDependencies = Object.keys(dependenciesObject);
-    const filteredRootDependencies = rootDependencies.filter((rootDependency) =>
-      dependenciesKeys.includes(rootDependency),
-    );
-    if (filteredRootDependencies.length > 0) {
-      const plural = filteredRootDependencies.length > 1;
-      console.log(`
+  const plural = filteredRootDependencies.length > 1;
+  console.log(`
  ${chalk.whiteBright.bgYellow.bold(
    'Webpack does not work with native dependencies.',
  )}
 ${chalk.bold(filteredRootDependencies.join(', '))} ${
-        plural ? 'are native dependencies' : 'is a native dependency'
-      } and should be installed inside of the "./release/app" folder.
+    plural ? 'are native dependencies' : 'is a native dependency'
+  } and should be installed inside of the "./release/app" folder.
  First, uninstall the packages from "./package.json":
 ${chalk.whiteBright.bgGreen.bold('npm uninstall your-package')}
  ${chalk.bold(
@@ -46,9 +37,5 @@ ${chalk.bold(
   'https://electron-react-boilerplate.js.org/docs/adding-dependencies/#module-structure',
 )}
  `);
-      process.exit(1);
-    }
-  } catch {
-    console.log('Native dependencies could not be checked');
-  }
+  process.exit(1);
 }


### PR DESCRIPTION
## Improve External Dependency Compatibility: Native Module Detection & DLL Exclusion Option

**Description**

While working with Electron React Boilerplate, I noticed that some external packages—especially those with native modules or special export/dynamic import requirements—were causing unexpected build failures.  
This PR updates the native module detection logic to be more accurate and adds a simple way for users to exclude problematic packages from the DLL bundle. I believe these changes will make it much easier to integrate a wider variety of dependencies without running into confusing errors.

**Changes Made**

- `.erb/scripts/check-native-dep.js`  
  - Updated the detection logic so that only packages with both a `binding.gyp` file and a direct entry in `package.json` dependencies are flagged as native.
  - Cleaned up the code by removing unnecessary `npm ls` parsing and the try-catch block.
- `.erb/configs/webpack.config.renderer.dev.dll.ts`  
  - Introduced a `dllExclude` array, allowing users to easily specify packages to exclude from the DLL bundle.
  - By default, this array is empty—users can add package names as needed for their setup.

**Why**

- I ran into issues where some packages were incorrectly flagged as native modules, which blocked development and caused unnecessary build failures.
- Additionally, certain packages would break the DLL build due to export or dynamic import issues, and there was no straightforward way to exclude them.
- With these changes, false positives are avoided, and users have more control over which packages are included in the DLL bundle.

**Testing**

- I tested with several packages that previously caused issues and confirmed they are no longer falsely detected as native.
- I also checked that adding package names to `dllExclude` successfully excludes them from the DLL bundle.
- The project continues to build and run as expected after these updates.
