### PR TITLE
fix: ESLint not running on typescript files since ESLint 3.0.11

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
     "javascript",
     "javascriptreact",
     "html",
+    "typescript",
     "typescriptreact"
   ],
 


### PR DESCRIPTION
There is no typescript entry in the settings.json file.

[ESLint started being more strict about this](https://github.com/microsoft/vscode-eslint/blob/main/CHANGELOG.md#version-3011---pre-release).

The addition of "typescript" re-enables the linting of .ts files. 