### PR TITLE
Fix: Debugger in renderer 

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -41,6 +41,15 @@ const isDebug =
 
 if (isDebug) {
   require('electron-debug').default();
+  let port = '9223';
+  if (process.env.MAIN_ARGS) {
+    port = (
+      [...process.env.MAIN_ARGS.matchAll(/"[^"]+"|[^\s"]+/g)]
+        .flat()
+        .filter((str) => str.includes('debugging-port'))[0] || '=9223'
+    ).split('=')[1];
+  }
+  app.commandLine.appendSwitch('remote-debugging-port', port);
 }
 
 const installExtensions = async () => {


### PR DESCRIPTION
## Fix: VSCode Debugger Renderer Port Issue

**Problem:**
The VSCode debugger was failing to start correctly, specifically because the debugger renderer was unable to locate the necessary port number. This issue prevented successful debugging of the application within the VSCode environment.

**Solution:**
This change implements a fix that ensures the port number is explicitly provided to the debugger renderer when the main process is initiated by the debugger. The solution was derived from investigating existing reported issues within the repository, indicating this is a known recurring problem.

**Replicate:**
1. Clone repo 
2. Install dependencies
3. Start debugger with `Electron: All` 
4. Error shown when renderer times out

**Impact:**
This resolves the debugger startup failure, allowing developers to seamlessly debug the application in VSCode.

**Visuals:**
See attached screenshots for the debugger's state before (error) and after (success) this fix.
| Before | After |
|--------|--------|
| <img width="364" height="384" alt="Screenshot 2025-10-16 at 6 48 48 AM" src="https://github.com/user-attachments/assets/b5977423-e4a5-4d02-a3c9-1261ceb6f6d8" /> | <img width="729" height="226" alt="Screenshot 2025-10-16 at 6 50 09 AM" src="https://github.com/user-attachments/assets/1d9ae7c7-0fe8-4b1d-aed2-f17df04948b5" /> | 