### PR TITLE
Change require to import for notarize module

### DIFF
--- a/.erb/scripts/notarize.js
+++ b/.erb/scripts/notarize.js
@@ -1,4 +1,4 @@
-const { notarize } = require('@electron/notarize');
+const { notarize } = import('@electron/notarize');
 const { build } = require('../../package.json');
 
 exports.default = async function notarizeMacos(context) {


### PR DESCRIPTION
Solve the following error:
Unable to `require`  moduleName=/home/... .../.erb/scripts/notarize.js message=require() of ES Module /home/... .../node_modules/@electron/notarize/lib/index.js from /... .../.erb/scripts/notarize.js not supported. That appear running:
npm run package